### PR TITLE
Encrypt Gort REST service communications 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ An incomplete list of tasks for Gort by milestone. Tasks listed within a milesto
 
 This is ABSOLUTELY NOT an exhaustive list. Please feel free to add to it. If what you want to add doesn't have an open issue, please [create one of these as well](https://github.com/clockworksoul/Gort/issues).
 
-## Milestone 4 (Command Bundles) -- *COMPLETE!* ✅
+## Milestone 4 (Command Bundles) -- _COMPLETE!_ ✅
 
 - The **Gort Guide** : [started here](https://getgort.github.io/gort-guide/bundles.html) ✅
 - Document how command bundles are _supposed_ to work. ✅
@@ -12,7 +12,7 @@ This is ABSOLUTELY NOT an exhaustive list. Please feel free to add to it. If wha
 
 ## Milestone 5 (Focus on Security)
 
-- Encrypt Gort REST service communications.
+- Encrypt Gort REST service communications. ✅
   - Allow a TLS certificate to be installed by Gort controller.
     - MUST loudly warn on startup if one is not being used.
   - Gortctl SHOULD warn when not using an encrypted connection.
@@ -39,7 +39,7 @@ This is ABSOLUTELY NOT an exhaustive list. Please feel free to add to it. If wha
 - Command invocations can be associated with a user; [execution rules](https://web.archive.org/web/20191130061912/http://book.cog.bot/sections/command_execution_rules.html).
 - Audit log for all API actions (user, timestamp, action taken, method (Slack, API, etc.))
 
-***(Publicly release v0.7.0-alpha.0 at this point)***
+**_(Publicly release v0.7.0-alpha.0 at this point)_**
 
 ## Milestone 8 (Remote relays)
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,49 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/getgort/gort/client"
+)
+
+func TestAllowInsecure(t *testing.T) {
+	var tests = []struct {
+		Name         string
+		ProfileEntry client.ProfileEntry
+		ExpectErr    bool
+	}{
+		{
+			Name: "allows secure URL",
+			ProfileEntry: client.ProfileEntry{
+				URLString: "https://example.com",
+			},
+		},
+		{
+			Name: "does not allow insecure URL",
+			ProfileEntry: client.ProfileEntry{
+				URLString: "http://example.com",
+			},
+			ExpectErr: true,
+		},
+		{
+			Name: "allows insecure URL if allowInsecure==true",
+			ProfileEntry: client.ProfileEntry{
+				URLString:     "http://example.com",
+				AllowInsecure: true,
+			},
+			ExpectErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			_, err := client.ConnectWithNewProfile(test.ProfileEntry)
+			if test.ExpectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/client/profile.go
+++ b/client/profile.go
@@ -21,9 +21,10 @@ import (
 	"net/url"
 	"os"
 
+	yaml "gopkg.in/yaml.v3"
+
 	"github.com/getgort/gort/data/rest"
 	gerrs "github.com/getgort/gort/errors"
-	yaml "gopkg.in/yaml.v3"
 )
 
 // Profile represents a set of user profiles from a $HOME/.gort/profiles file
@@ -51,11 +52,13 @@ type ProfileDefaults struct {
 
 // ProfileEntry represents a single profile entry.
 type ProfileEntry struct {
-	Name      string   `yaml:"-"`
-	URLString string   `yaml:"url"`
-	Password  string   `yaml:"password"`
-	URL       *url.URL `yaml:"-"`
-	Username  string   `yaml:"user"`
+	Name          string   `yaml:"-"`
+	URLString     string   `yaml:"url"`
+	Password      string   `yaml:"password"`
+	URL           *url.URL `yaml:"-"`
+	Username      string   `yaml:"user"`
+	AllowInsecure bool     `yaml:"allow_insecure"`
+	TLSCertFile   string   `yaml:"tls_cert_file"`
 }
 
 // User is a convenience method that returns a rest.User pre-set with the

--- a/config.yml
+++ b/config.yml
@@ -26,6 +26,15 @@ gort:
   # via direct mentions. Defaults to true.
   enable_spoken_commands: true
 
+  # If set along with tls_key_file, TLS will be used for API connections.
+  # This parameter specifies the path to a certificate file.
+  # tls_cert_file: host.crt
+
+  # If set alsong with tls_cert_file, TLS will be used for API connections.
+  # This parameter specifies the path to a key file.
+  # The key must not be encrypted with a password.
+  # tls_key_file: host.key
+
 # Not yet supported
 database:
   # The host where Gort's PostgreSQL database lives. Defaults to localhost.

--- a/data/config.go
+++ b/data/config.go
@@ -33,6 +33,8 @@ type GortServerConfigs struct {
 	APIURLBase            string `yaml:"api_url_base,omitempty"`
 	DevelopmentMode       bool   `yaml:"development_mode,omitempty"`
 	EnableSpokenCommands  bool   `yaml:"enable_spoken_commands,omitempty"`
+	TLSCertFile           string `yaml:"tls_cert_file,omitempty"`
+	TLSKeyFile            string `yaml:"tls_key_file,omitempty"`
 }
 
 // GlobalConfigs is the data wrapper for the "global" section


### PR DESCRIPTION
A TLS cert and key may be provided in the gort config to use TLS for the
API.

gortctl defaults to expecting https, but http may be allowed using
allow_insecure.

Tested with unit tests, and by using a trusted, self-signed certificate
for localhost.