### PR TITLE
v0.7.8-dev.0 Implement rule condition expression parsing

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -64,11 +64,11 @@ func (c CommandParameters) String() string {
 	}
 
 	b := strings.Builder{}
-	b.WriteString(c[0].String())
+	b.WriteString(fmt.Sprintf("%v", c[0]))
 
 	for i := 0; i < len(c); i++ {
 		b.WriteRune(' ')
-		b.WriteString(c[i].String())
+		b.WriteString(fmt.Sprintf("%v", c[i]))
 	}
 
 	return b.String()
@@ -236,7 +236,7 @@ func buildOption(name string, po *parseOptions) *CommandOption {
 		name = n
 	}
 
-	return &CommandOption{Name: name, Value: types.BoolValue{Value: true}}
+	return &CommandOption{Name: name, Value: types.BoolValue{V: true}}
 }
 
 func dashCount(str string) int {

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -32,12 +32,12 @@ func TestCommandParseEmpty(t *testing.T) {
 func TestCommandParseDefaults(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:              {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
-		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{Value: true}}}, []Value{stringValue("foo"), stringValue("bar")}},
-		`bar:echo -n foo -E bar`:          {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{Value: true}}}, []Value{stringValue("foo"), stringValue("-E"), stringValue("bar")}},
-		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{Value: true}}}, []Value{StringValue{Value: "foo bar", Quote: '"'}}},
+		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
+		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{V: true}}}, []Value{stringValue("foo"), stringValue("bar")}},
+		`bar:echo -n foo -E bar`:          {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{V: true}}}, []Value{stringValue("foo"), stringValue("-E"), stringValue("bar")}},
+		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{V: true}}}, []Value{StringValue{V: "foo bar", Quote: '"'}}},
 	}
 
 	for test, expected := range tests {
@@ -56,11 +56,11 @@ func TestCommandOptionTypes(t *testing.T) {
 
 	expected := Command{"", "test",
 		map[string]CommandOption{
-			"flag":     {"flag", BoolValue{Value: true}},
-			"int":      {"int", IntValue{Value: 10}},
-			"float":    {"float", FloatValue{Value: 0.1}},
-			"notregex": {"notregex", StringValue{Value: `/^foo$/`, Quote: '"'}},
-			"string":   {"string", StringValue{Value: "str"}},
+			"flag":     {"flag", BoolValue{V: true}},
+			"int":      {"int", IntValue{V: 10}},
+			"float":    {"float", FloatValue{V: 0.1}},
+			"notregex": {"notregex", StringValue{V: `/^foo$/`, Quote: '"'}},
+			"string":   {"string", StringValue{V: "str"}},
 		},
 		[]Value{stringValue("this"), stringValue("is"), stringValue("text")},
 	}
@@ -82,12 +82,12 @@ func TestCommandParameterTypes(t *testing.T) {
 	expected := Command{"", "test",
 		map[string]CommandOption{},
 		[]Value{
-			StringValue{Value: "string", Quote: '\u0000'},
-			FloatValue{Value: 10.0},
-			IntValue{Value: 42},
-			BoolValue{Value: false},
-			StringValue{Value: "foo bar", Quote: '"'},
-			StringValue{Value: "/^.*$/", Quote: '\u0000'},
+			StringValue{V: "string", Quote: '\u0000'},
+			FloatValue{V: 10.0},
+			IntValue{V: 42},
+			BoolValue{V: false},
+			StringValue{V: "foo bar", Quote: '"'},
+			StringValue{V: "/^.*$/", Quote: '\u0000'},
 		},
 	}
 
@@ -102,12 +102,12 @@ func TestCommandParameterTypes(t *testing.T) {
 }
 
 func TestCommandParseBareFlagsAreTrue(t *testing.T) {
-	tv := BoolValue{Value: true}
+	tv := BoolValue{V: true}
 
 	tests := map[string]Command{
 		`foo:curl -Ik localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", tv}, "k": {"k", tv}}, []Value{stringValue("localhost")}},
 		`bar:echo -n foo -E bar`: {`bar`, `echo`, map[string]CommandOption{"n": {"n", tv}}, []Value{stringValue("foo"), stringValue("-E"), stringValue("bar")}},
-		`bar:echo -n "foo bar"`:  {`bar`, `echo`, map[string]CommandOption{"n": {"n", tv}}, []Value{StringValue{Value: "foo bar", Quote: '"'}}},
+		`bar:echo -n "foo bar"`:  {`bar`, `echo`, map[string]CommandOption{"n": {"n", tv}}, []Value{StringValue{V: "foo bar", Quote: '"'}}},
 	}
 
 	for test, expected := range tests {
@@ -124,10 +124,10 @@ func TestCommandParseBareFlagsAreTrue(t *testing.T) {
 func TestCommandParseAgnosticDashesTrue(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:              {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{Value: true}}, "ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{Value: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
+		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{V: true}}, "ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"Ik": {"Ik", BoolValue{V: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
 	}
 
 	options := []ParseOption{ParseAgnosticDashes(true)}
@@ -146,12 +146,12 @@ func TestCommandParseAgnosticDashesTrue(t *testing.T) {
 func TestCommandParseAssumeOptionArgumentsTrue(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:              {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", StringValue{Value: "localhost", Quote: '\u0000'}}}, []Value{}},
-		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", StringValue{Value: "localhost", Quote: '\u0000'}}}, []Value{}},
-		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}, "ssl": {"ssl", StringValue{Value: "localhost", Quote: '\u0000'}}}, []Value{}},
-		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
-		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", StringValue{Value: "foo", Quote: '\u0000'}}}, []Value{stringValue("bar")}},
-		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", StringValue{Value: "foo bar", Quote: '"'}}}, []Value{}},
+		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", StringValue{V: "localhost", Quote: '\u0000'}}}, []Value{}},
+		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", StringValue{V: "localhost", Quote: '\u0000'}}}, []Value{}},
+		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}, "ssl": {"ssl", StringValue{V: "localhost", Quote: '\u0000'}}}, []Value{}},
+		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
+		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", StringValue{V: "foo", Quote: '\u0000'}}}, []Value{stringValue("bar")}},
+		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", StringValue{V: "foo bar", Quote: '"'}}}, []Value{}},
 	}
 
 	options := []ParseOption{ParseAssumeOptionArguments(true)}
@@ -170,12 +170,12 @@ func TestCommandParseAssumeOptionArgumentsTrue(t *testing.T) {
 func TestCommandParseAssumeOptionArgumentsFalse(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:              {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}, "ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
-		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{Value: true}}}, []Value{stringValue("foo"), stringValue("bar")}},
-		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{Value: true}}}, []Value{StringValue{Value: "foo bar", Quote: '"'}}},
+		`foo:curl -Ik localhost`:          {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl --ssl localhost`:        {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik --ssl localhost`:    {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}, "ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik -- --ssl localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("--ssl"), stringValue("localhost")}},
+		`bar:echo -n foo bar`:             {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{V: true}}}, []Value{stringValue("foo"), stringValue("bar")}},
+		`bar:echo -n "foo bar"`:           {`bar`, `echo`, map[string]CommandOption{"n": {"n", BoolValue{V: true}}}, []Value{StringValue{V: "foo bar", Quote: '"'}}},
 	}
 
 	options := []ParseOption{ParseAssumeOptionArguments(false)}
@@ -194,9 +194,9 @@ func TestCommandParseAssumeOptionArgumentsFalse(t *testing.T) {
 func TestCommandParseOptionHasArgument(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:                 {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:             {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl --ssl localhost`:           {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik --cert file localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}, "cert": {"cert", StringValue{Value: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik localhost`:             {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl --ssl localhost`:           {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik --cert file localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}, "cert": {"cert", StringValue{V: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
 	}
 
 	options := []ParseOption{
@@ -220,10 +220,10 @@ func TestCommandParseOptionHasArgument(t *testing.T) {
 func TestCommandParseOptionAlias(t *testing.T) {
 	tests := map[string]Command{
 		`foo:curl localhost`:                 {`foo`, `curl`, map[string]CommandOption{}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik localhost`:             {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl --ssl localhost`:           {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{Value: true}}}, []Value{stringValue("localhost")}},
-		`foo:curl -Ik --cert file localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{Value: true}}, "k": {"k", BoolValue{Value: true}}, "cert": {"cert", StringValue{Value: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
-		`foo:curl -E file localhost`:         {`foo`, `curl`, map[string]CommandOption{"cert": {"cert", StringValue{Value: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik localhost`:             {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl --ssl localhost`:           {`foo`, `curl`, map[string]CommandOption{"ssl": {"ssl", BoolValue{V: true}}}, []Value{stringValue("localhost")}},
+		`foo:curl -Ik --cert file localhost`: {`foo`, `curl`, map[string]CommandOption{"I": {"I", BoolValue{V: true}}, "k": {"k", BoolValue{V: true}}, "cert": {"cert", StringValue{V: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
+		`foo:curl -E file localhost`:         {`foo`, `curl`, map[string]CommandOption{"cert": {"cert", StringValue{V: "file", Quote: '\u0000'}}}, []Value{stringValue("localhost")}},
 	}
 
 	options := []ParseOption{
@@ -263,5 +263,5 @@ func TestSplitCommand(t *testing.T) {
 }
 
 func stringValue(s string) Value {
-	return StringValue{Value: s, Quote: '\u0000'}
+	return StringValue{V: s, Quote: '\u0000'}
 }

--- a/rules/condition.go
+++ b/rules/condition.go
@@ -24,6 +24,6 @@ type Expression struct {
 	Operator Operator
 }
 
-func (e Expression) Evaluate() (bool, error) {
+func (e Expression) Evaluate() bool {
 	return e.Operator(e.A, e.B)
 }

--- a/rules/operator.go
+++ b/rules/operator.go
@@ -17,59 +17,36 @@
 package rules
 
 import (
-	"fmt"
-
 	"github.com/getgort/gort/types"
 )
 
-type Operator func(a, b types.Value) (bool, error)
+type Operator func(a, b types.Value) bool
 
-func Equals(a, b types.Value) (bool, error) {
+func Equals(a, b types.Value) bool {
 	return a.Equals(b)
 }
 
-func NotEquals(a, b types.Value) (bool, error) {
-	eq, err := a.Equals(b)
-	return !eq, err
+func NotEquals(a, b types.Value) bool {
+	return !a.Equals(b)
 }
 
-func LessThan(a, b types.Value) (bool, error) {
+func LessThan(a, b types.Value) bool {
 	return a.LessThan(b)
 }
 
-func LessThanOrEqualTo(a, b types.Value) (bool, error) {
-	lt, err := a.LessThan(b)
-	if err != nil {
-		return false, err
-	}
-
-	eq, err := a.Equals(b)
-	if err != nil {
-		return false, err
-	}
-
-	return lt || eq, nil
+func LessThanOrEqualTo(a, b types.Value) bool {
+	return a.LessThan(b) || a.Equals(b)
 }
 
-func GreaterThan(a, b types.Value) (bool, error) {
-	lt, err := a.LessThan(b)
-	if err != nil {
-		return false, err
-	}
-
-	eq, err := a.Equals(b)
-	if err != nil {
-		return false, err
-	}
-
-	return !(lt || eq), nil
+func GreaterThan(a, b types.Value) bool {
+	return !(a.LessThan(b) || a.Equals(b))
 }
 
-func GreaterThanOrEqualTo(a, b types.Value) (bool, error) {
-	lt, err := a.LessThan(b)
-	return !lt, err
+func GreaterThanOrEqualTo(a, b types.Value) bool {
+	return !a.LessThan(b)
 }
 
-func In(a, b types.Value) (bool, error) {
-	return false, fmt.Errorf("not implemented")
+func In(a, b types.Value) bool {
+	// Not implemented
+	return false
 }

--- a/rules/operator_test.go
+++ b/rules/operator_test.go
@@ -17,6 +17,7 @@
 package rules
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/getgort/gort/types"
@@ -26,151 +27,82 @@ import (
 func TestOperatorEquals(t *testing.T) {
 	evaluate := Equals
 
-	result, err := evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.True(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.False(t, result)
+}
+
+func TestOperatorRegexpEquals(t *testing.T) {
+	re := regexp.MustCompile(`^(.*)\s+([!>=]{1,2}|in)\s+(.*)$`)
+	test := "option['delete'] in true"
+
+	subs := re.FindStringSubmatch(test)
+
+	for _, s := range subs {
+		t.Log(s)
 	}
 }
 
 func TestOperatorNotEquals(t *testing.T) {
 	evaluate := NotEquals
 
-	result, err := evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.False(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.True(t, result)
 }
 
 func TestOperatorLessThan(t *testing.T) {
 	evaluate := LessThan
 
-	result, err := evaluate(types.IntValue{Value: 21}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 21}, types.IntValue{V: 42})
+	assert.True(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.False(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.False(t, result)
 }
 
 func TestOperatorLessThanOrEqualTo(t *testing.T) {
 	evaluate := LessThanOrEqualTo
 
-	result, err := evaluate(types.IntValue{Value: 21}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 21}, types.IntValue{V: 42})
+	assert.True(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.True(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.False(t, result)
 }
 
 func TestOperatorGreaterThan(t *testing.T) {
 	evaluate := GreaterThan
 
-	result, err := evaluate(types.IntValue{Value: 21}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 21}, types.IntValue{V: 42})
+	assert.False(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.False(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.True(t, result)
 }
 
 func TestOperatorGreaterThanOrEqualTo(t *testing.T) {
 	evaluate := GreaterThanOrEqualTo
 
-	result, err := evaluate(types.IntValue{Value: 21}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.False(t, result) {
-		t.FailNow()
-	}
+	result := evaluate(types.IntValue{V: 21}, types.IntValue{V: 42})
+	assert.False(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 42})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 42})
+	assert.True(t, result)
 
-	result, err = evaluate(types.IntValue{Value: 42}, types.IntValue{Value: 21})
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.True(t, result) {
-		t.FailNow()
-	}
+	result = evaluate(types.IntValue{V: 42}, types.IntValue{V: 21})
+	assert.True(t, result)
 }

--- a/rules/parse.go
+++ b/rules/parse.go
@@ -16,6 +16,13 @@
 
 package rules
 
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/getgort/gort/types"
+)
+
 func Parse(rt RuleTokens) (Rule, error) {
 	r := Rule{
 		Command:     rt.Command,
@@ -23,5 +30,61 @@ func Parse(rt RuleTokens) (Rule, error) {
 		Permissions: rt.Permissions,
 	}
 
+	for _, c := range rt.Conditions {
+		a, b, o, err := ParseExpression(c)
+		if err != nil {
+			return r, fmt.Errorf("can't parse condition: %w", err)
+		}
+
+		va, err := types.Infer(a, false, true)
+		if err != nil {
+			return r, fmt.Errorf("can't infer value: %w", err)
+		}
+
+		vb, err := types.Infer(b, false, true)
+		if err != nil {
+			return r, fmt.Errorf("can't infer value: %w", err)
+		}
+
+		r.Conditions = append(r.Conditions, Expression{A: va, B: vb, Operator: o})
+	}
+
 	return r, nil
+}
+
+var (
+	reOperatorParts = regexp.MustCompile(`^(.*)\s+([!<>=]{1,2}|in)\s+(.*)$`)
+)
+
+func ParseExpression(expr string) (a, b string, o Operator, err error) {
+	subs := reOperatorParts.FindStringSubmatch(expr)
+
+	if len(subs) != 4 {
+		err = fmt.Errorf("expression doesn't conform to form A OP B")
+		return
+	}
+
+	op := subs[2]
+	a, b = subs[1], subs[3]
+
+	switch op {
+	case "==":
+		o = Equals
+	case "!=":
+		o = NotEquals
+	case "<":
+		o = LessThan
+	case "<=":
+		o = LessThanOrEqualTo
+	case ">":
+		o = GreaterThan
+	case ">=":
+		o = GreaterThanOrEqualTo
+	case "in":
+		o = In
+	default:
+		err = fmt.Errorf("unsupported operator: %s", op)
+	}
+
+	return
 }

--- a/rules/parse_test.go
+++ b/rules/parse_test.go
@@ -17,15 +17,21 @@
 package rules
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/getgort/gort/types"
 )
 
 func TestParse(t *testing.T) {
 	inputs := map[string]Rule{
 		`foo:bar allow`: {Command: "foo:bar", Conditions: []Expression{}, Permissions: []string{}},
-		`foo:bar with option['delete'] == true must have foo:destroy`: {Command: "foo:bar", Conditions: []Expression{}, Permissions: []string{"foo:destroy"}},
+		`foo:bar with option['delete'] == true must have foo:destroy`: {
+			Command:     "foo:bar",
+			Conditions:  []Expression{{A: types.MapValue{Name: "option", Key: "delete"}, B: types.BoolValue{V: true}, Operator: Equals}},
+			Permissions: []string{"foo:destroy"}},
 	}
 
 	for in, expected := range inputs {
@@ -34,26 +40,76 @@ func TestParse(t *testing.T) {
 			continue
 		}
 
-		for i, c := range rt.Conditions {
-			t.Log(i, c)
-
-			// Patterns:
-			//
-			// 1 each of:
-			//
-			// $VALUE_A
-			// any $SET_A
-			// all $SET_A
-			//
-			// OP $VALUE_B
-			// in $SET_B
-		}
-
 		rule, err := Parse(rt)
 		if !assert.NoError(t, err, in) {
 			continue
 		}
 
-		assert.Equal(t, expected, rule, in)
+		assert.Equal(t, expected.Command, rule.Command, in)
+
+		for i, e := range expected.Conditions {
+			assert.EqualValues(t, e.A, rule.Conditions[i].A)
+			assert.EqualValues(t, e.B, rule.Conditions[i].B)
+			assert.Equal(t, fmt.Sprintf("%v", e.Operator), fmt.Sprintf("%v", rule.Conditions[i].Operator))
+		}
+
+		assert.Equal(t, expected.Permissions, rule.Permissions, in)
+	}
+}
+
+func TestParseExpression(t *testing.T) {
+	type Expected struct {
+		a, b string
+		o    Operator
+	}
+
+	inputs := map[string][]Expected{
+		`foo:bar with option[foo] in ["foo", "bar"] allow`:                                                  {{a: `option[foo]`, b: `["foo", "bar"]`, o: In}},
+		`foo:bar with option['delete'] == true must have foo:destroy`:                                       {{a: `option['delete']`, b: `true`, o: Equals}},
+		`foo:set with option['set'] == /.*/ must have foo:baz-set`:                                          {{a: `option['set']`, b: `/.*/`, o: Equals}},
+		`foo:qux with arg[0] == 'status' must have foo:view`:                                                {{a: `arg[0]`, b: `'status'`, o: Equals}},
+		`foo:barqux with option['delete'] == true and arg[0] > 5 must have foo:destroy`:                     {{a: `option['delete']`, b: `true`, o: Equals}, {a: `arg[0]`, b: `5`, o: GreaterThan}},
+		`foo:bar with any arg in ['wubba'] must have foo:read`:                                              {{a: `any arg`, b: `['wubba']`, o: In}},
+		`foo:bar with any arg in ['wubba', /^f.*/, 10] must have foo:read`:                                  {{a: `any arg`, b: `['wubba', /^f.*/, 10]`, o: In}},
+		`foo:bar with all arg in [10, 'baz', 'wubba'] must have foo:read`:                                   {{a: `all arg`, b: `[10, 'baz', 'wubba']`, o: In}},
+		`foo:bar with arg[0] in ['baz', false, 100] must have foo:read`:                                     {{a: `arg[0]`, b: `['baz', false, 100]`, o: In}},
+		`foo:bar with any option != /^prod.*/ must have foo:read`:                                           {{a: `any option`, b: `/^prod.*/`, o: NotEquals}},
+		`foo:bar with all option == 10 must have foo:read`:                                                  {{a: `all option`, b: `10`, o: Equals}},
+		`foo:bar with all option < 10 must have foo:read`:                                                   {{a: `all option`, b: `10`, o: LessThan}},
+		`foo:bar with all option <= 10 must have foo:read`:                                                  {{a: `all option`, b: `10`, o: LessThanOrEqualTo}},
+		`foo:bar with all option > 10 must have foo:read`:                                                   {{a: `all option`, b: `10`, o: GreaterThan}},
+		`foo:bar with all option >= 10 must have foo:read`:                                                  {{a: `all option`, b: `10`, o: GreaterThanOrEqualTo}},
+		`foo:bar with all option != 10 must have foo:read`:                                                  {{a: `all option`, b: `10`, o: NotEquals}},
+		`foo:deploy with option["environment"] == 'prod' must have all in [site:it, site:prod, foo:deploy]`: {{a: `option["environment"]`, b: `'prod'`, o: Equals}},
+		`foo:patch must have all in [foo:patch, site:it]
+			or all in [site:qa, site:test, foo:patch]
+			or all in [site:eng, site:stage, foo:patch]`: {{}},
+		`foo:bar
+		    with option['delete'] == true
+			   must have foo:destroy`: {{a: `option['delete']`, b: `true`, o: Equals}},
+	}
+
+	for in, expected := range inputs {
+		rt, err := Tokenize(in)
+		if !assert.NoError(t, err, in) {
+			continue
+		}
+
+		for i := 0; i < len(rt.Conditions); i += 2 {
+			expr := rt.Conditions[i]
+			a, b, o, err := ParseExpression(expr)
+
+			// Workaround for function comparison
+			os := fmt.Sprintf("%v", o)
+			eos := fmt.Sprintf("%v", expected[i/2].o)
+
+			if !assert.NoError(t, err, in) ||
+				!assert.Equal(t, expected[i/2].a, a, in) ||
+				!assert.Equal(t, expected[i/2].b, b, in) ||
+				!assert.Equal(t, eos, os, in) {
+
+				t.Logf("Erroneous expression: %q", expr)
+			}
+		}
 	}
 }

--- a/rules/tokenize.go
+++ b/rules/tokenize.go
@@ -17,6 +17,7 @@
 package rules
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -30,6 +31,12 @@ type RuleTokens struct {
 	Command     string
 	Conditions  []string
 	Permissions []string
+}
+
+// String is mostly used for debugging.
+func (r RuleTokens) String() string {
+	b, _ := json.Marshal(r)
+	return string(b)
 }
 
 // Tokenize accepts a raw Gort rule of the form "COMMAND [when CONDITION

--- a/rules/tokenize_test.go
+++ b/rules/tokenize_test.go
@@ -38,7 +38,7 @@ func TestTokenize(t *testing.T) {
 		`foo:bar with arg[0] in ['baz', false, 100] must have foo:read`:                                     {`foo:bar`, []string{`arg[0] in ['baz', false, 100]`}, []string{`foo:read`}},
 		`foo:bar with any option == /^prod.*/ must have foo:read`:                                           {`foo:bar`, []string{`any option == /^prod.*/`}, []string{`foo:read`}},
 		`foo:bar with all option < 10 must have foo:read`:                                                   {`foo:bar`, []string{`all option < 10`}, []string{`foo:read`}},
-		`foo:bar with all options in ['staging', 'list'] must have foo:read`:                                {`foo:bar`, []string{`all options in ['staging', 'list']`}, []string{`foo:read`}},
+		`foo:bar with all option in ['staging', 'list'] must have foo:read`:                                 {`foo:bar`, []string{`all option in ['staging', 'list']`}, []string{`foo:read`}},
 		`foo:deploy with option["environment"] == 'prod' must have all in [site:it, site:prod, foo:deploy]`: {`foo:deploy`, []string{`option["environment"] == 'prod'`}, []string{`all in [site:it, site:prod, foo:deploy]`}},
 		`foo:deploy with option["environment"] == 'qa' must have site:test and foo:deploy`:                  {`foo:deploy`, []string{`option["environment"] == 'qa'`}, []string{`site:test`, `and`, `foo:deploy`}},
 		`foo:deploy with option["environment"] == 'stage' must have site:stage and foo:deploy`:              {`foo:deploy`, []string{`option["environment"] == 'stage'`}, []string{`site:stage`, `and`, `foo:deploy`}},

--- a/types/value_test.go
+++ b/types/value_test.go
@@ -28,51 +28,33 @@ func TestBoolValueEquals(t *testing.T) {
 		Input      bool
 		ComparedTo Value
 	}
-	type Expected struct {
-		Result   bool
-		HasError bool
-	}
 
-	tests := map[Test]Expected{
-		{false, BoolValue{Value: false}}:      {true, false},
-		{false, BoolValue{Value: true}}:       {false, false},
-		{true, BoolValue{Value: false}}:       {false, false},
-		{false, FloatValue{Value: 0.0}}:       {false, true},
-		{false, IntValue{Value: 0}}:           {true, false},
-		{false, RegexValue{Value: `^false$`}}: {true, false},
-		{false, StringValue{Value: "false"}}:  {true, false},
-		{true, BoolValue{Value: true}}:        {true, false},
-		{true, FloatValue{Value: 0.0}}:        {false, true},
-		{true, IntValue{Value: 1}}:            {true, false},
-		{true, RegexValue{Value: `^true$`}}:   {true, false},
-		{true, StringValue{Value: "true"}}:    {true, false},
-		{true, IntValue{Value: 2}}:            {false, true},
-		{false, StringValue{Value: "foo"}}:    {false, true},
+	tests := map[Test]bool{
+		{false, BoolValue{V: false}}:      true,
+		{false, BoolValue{V: true}}:       false,
+		{true, BoolValue{V: false}}:       false,
+		{false, FloatValue{V: 0.0}}:       false,
+		{false, IntValue{V: 0}}:           true,
+		{false, RegexValue{V: `^false$`}}: true,
+		{false, StringValue{V: "false"}}:  true,
+		{true, BoolValue{V: true}}:        true,
+		{true, FloatValue{V: 0.0}}:        false,
+		{true, IntValue{V: 1}}:            true,
+		{true, RegexValue{V: `^true$`}}:   true,
+		{true, StringValue{V: "true"}}:    true,
+		{true, IntValue{V: 2}}:            false,
+		{false, StringValue{V: "foo"}}:    false,
 	}
 
 	for test, expected := range tests {
-		input := BoolValue{Value: test.Input}
+		input := BoolValue{V: test.Input}
 		comparedTo := test.ComparedTo
 
-		result, err := input.Equals(comparedTo)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
+		result := input.Equals(comparedTo)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
-
-		result, err = comparedTo.Equals(input)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
+		result = comparedTo.Equals(input)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 	}
 }
 
@@ -82,54 +64,35 @@ func TestFloatValueEquals(t *testing.T) {
 		ComparedTo Value
 	}
 
-	type Expected struct {
-		Result   bool
-		HasError bool
-	}
-
-	tests := map[Test]Expected{
-		{0.0, BoolValue{Value: false}}:       {false, true},
-		{0.0, FloatValue{Value: 0.0}}:        {true, false},
-		{0.0, FloatValue{Value: 1.0}}:        {false, false},
-		{0.0, FloatValue{Value: -1.0}}:       {false, false},
-		{0.0, IntValue{Value: 0}}:            {true, false},
-		{0.0, RegexValue{Value: `^0.0*$`}}:   {true, false},
-		{0.0, StringValue{Value: "0.0"}}:     {false, true},
-		{1.0, BoolValue{Value: true}}:        {false, true},
-		{1.0, FloatValue{Value: 1.0}}:        {true, false},
-		{1.0, IntValue{Value: 1}}:            {true, false},
-		{1.0, RegexValue{Value: `^1.0*$`}}:   {true, false},
-		{1.0, StringValue{Value: "1.0"}}:     {false, true},
-		{-1.0, BoolValue{Value: false}}:      {false, true},
-		{-1.0, FloatValue{Value: -1.0}}:      {true, false},
-		{-1.0, IntValue{Value: -1}}:          {true, false},
-		{-1.0, RegexValue{Value: `^-1.0*$`}}: {true, false},
-		{-1.0, StringValue{Value: "-1.0"}}:   {false, true},
+	tests := map[Test]bool{
+		{0.0, BoolValue{V: false}}:          false,
+		{0.0, FloatValue{V: 0.0}}:           true,
+		{0.0, FloatValue{V: 1.0}}:           false,
+		{0.0, FloatValue{V: -1.0}}:          false,
+		{0.0, IntValue{V: 0}}:               true,
+		{0.0, RegexValue{V: `^0(.0*)?$`}}:   true,
+		{0.0, StringValue{V: "0.0"}}:        false,
+		{1.0, BoolValue{V: true}}:           false,
+		{1.0, FloatValue{V: 1.0}}:           true,
+		{1.0, IntValue{V: 1}}:               true,
+		{1.0, RegexValue{V: `^1(.0*)?$`}}:   true,
+		{1.0, StringValue{V: "1.0"}}:        false,
+		{-1.0, BoolValue{V: false}}:         false,
+		{-1.0, FloatValue{V: -1.0}}:         true,
+		{-1.0, IntValue{V: -1}}:             true,
+		{-1.0, RegexValue{V: `^-1(.0*)?$`}}: true,
+		{-1.0, StringValue{V: "-1.0"}}:      false,
 	}
 
 	for test, expected := range tests {
-		input := FloatValue{Value: test.Input}
+		input := FloatValue{V: test.Input}
 		comparedTo := test.ComparedTo
 
-		result, err := input.Equals(comparedTo)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
+		result := input.Equals(comparedTo)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
-
-		result, err = comparedTo.Equals(input)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
+		result = comparedTo.Equals(input)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 	}
 }
 
@@ -139,52 +102,33 @@ func TestIntValueEquals(t *testing.T) {
 		ComparedTo Value
 	}
 
-	type Expected struct {
-		Result   bool
-		HasError bool
-	}
-
-	tests := map[Test]Expected{
-		{0, BoolValue{Value: false}}:     {true, false},
-		{0, FloatValue{Value: 0.0}}:      {true, false},
-		{0, IntValue{Value: 0}}:          {true, false},
-		{0, RegexValue{Value: `^0*$`}}:   {true, false},
-		{0, StringValue{Value: "0"}}:     {false, true},
-		{1, BoolValue{Value: true}}:      {true, false},
-		{1, FloatValue{Value: 1.0}}:      {true, false},
-		{1, IntValue{Value: 1}}:          {true, false},
-		{1, RegexValue{Value: `^1*$`}}:   {true, false},
-		{1, StringValue{Value: "1"}}:     {false, true},
-		{-1, BoolValue{Value: false}}:    {false, true},
-		{-1, FloatValue{Value: -1.0}}:    {true, false},
-		{-1, IntValue{Value: -1}}:        {true, false},
-		{-1, RegexValue{Value: `^-1*$`}}: {true, false},
-		{-1, StringValue{Value: "-1"}}:   {false, true},
+	tests := map[Test]bool{
+		{0, BoolValue{V: false}}:     true,
+		{0, FloatValue{V: 0.0}}:      true,
+		{0, IntValue{V: 0}}:          true,
+		{0, RegexValue{V: `^0*$`}}:   true,
+		{0, StringValue{V: "0"}}:     false,
+		{1, BoolValue{V: true}}:      true,
+		{1, FloatValue{V: 1.0}}:      true,
+		{1, IntValue{V: 1}}:          true,
+		{1, RegexValue{V: `^1*$`}}:   true,
+		{1, StringValue{V: "1"}}:     false,
+		{-1, BoolValue{V: false}}:    false,
+		{-1, FloatValue{V: -1.0}}:    true,
+		{-1, IntValue{V: -1}}:        true,
+		{-1, RegexValue{V: `^-1*$`}}: true,
+		{-1, StringValue{V: "-1"}}:   false,
 	}
 
 	for test, expected := range tests {
-		input := IntValue{Value: test.Input}
+		input := IntValue{V: test.Input}
 		comparedTo := test.ComparedTo
 
-		result, err := input.Equals(comparedTo)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
+		result := input.Equals(comparedTo)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
-
-		result, err = comparedTo.Equals(input)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
+		result = comparedTo.Equals(input)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 	}
 }
 
@@ -194,46 +138,27 @@ func TestRegexValueEquals(t *testing.T) {
 		ComparedTo Value
 	}
 
-	type Expected struct {
-		Result   bool
-		HasError bool
-	}
-
-	tests := map[Test]Expected{
-		{`^false$`, BoolValue{Value: false}}: {true, false},
-		{`^false$`, BoolValue{Value: true}}:  {false, false},
-		{`^0.0*$`, FloatValue{Value: 0.0}}:   {true, false},
-		{`^0.0*$`, FloatValue{Value: 1.0}}:   {false, false},
-		{`^0$`, IntValue{Value: 0}}:          {true, false},
-		{`^0$`, IntValue{Value: 1}}:          {false, false},
-		{`^.*$`, RegexValue{Value: `^.*$`}}:  {false, true},
-		{`^foo$`, StringValue{Value: `foo`}}: {true, false},
-		{`^foo$`, StringValue{Value: "bar"}}: {false, false},
+	tests := map[Test]bool{
+		{`^false$`, BoolValue{V: false}}:  true,
+		{`^false$`, BoolValue{V: true}}:   false,
+		{`^0(.0*)?$`, FloatValue{V: 0.0}}: true,
+		{`^0(.0*)?$`, FloatValue{V: 1.0}}: false,
+		{`^0$`, IntValue{V: 0}}:           true,
+		{`^0$`, IntValue{V: 1}}:           false,
+		{`^.*$`, RegexValue{V: `^.*$`}}:   true,
+		{`^foo$`, StringValue{V: `foo`}}:  true,
+		{`^foo$`, StringValue{V: "bar"}}:  false,
 	}
 
 	for test, expected := range tests {
-		input := RegexValue{Value: test.Input}
+		input := RegexValue{V: test.Input}
 		comparedTo := test.ComparedTo
 
-		result, err := input.Equals(comparedTo)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
+		result := input.Equals(comparedTo)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
-
-		result, err = comparedTo.Equals(input)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
+		result = comparedTo.Equals(input)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 	}
 }
 
@@ -243,43 +168,24 @@ func TestStringValueEquals(t *testing.T) {
 		ComparedTo Value
 	}
 
-	type Expected struct {
-		Result   bool
-		HasError bool
-	}
-
-	tests := map[Test]Expected{
-		{"foo", BoolValue{Value: false}}:   {false, true},
-		{"foo", FloatValue{Value: 0.0}}:    {false, true},
-		{"foo", IntValue{Value: 0}}:        {false, true},
-		{"foo", RegexValue{Value: `^.*$`}}: {true, false},
-		{"foo", StringValue{Value: "foo"}}: {true, false},
-		{"foo", StringValue{Value: "0"}}:   {false, false},
+	tests := map[Test]bool{
+		{"foo", BoolValue{V: false}}:   false,
+		{"foo", FloatValue{V: 0.0}}:    false,
+		{"foo", IntValue{V: 0}}:        false,
+		{"foo", RegexValue{V: `^.*$`}}: true,
+		{"foo", StringValue{V: "foo"}}: true,
+		{"foo", StringValue{V: "0"}}:   false,
 	}
 
 	for test, expected := range tests {
-		input := StringValue{Value: test.Input}
+		input := StringValue{V: test.Input}
 		comparedTo := test.ComparedTo
 
-		result, err := input.Equals(comparedTo)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
+		result := input.Equals(comparedTo)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
-
-		result, err = comparedTo.Equals(input)
-		if expected.HasError && !assert.Error(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-		if !expected.HasError && !assert.NoError(t, err, msg(test.Input, test.ComparedTo)) {
-			continue
-		}
-
-		assert.Equal(t, expected.Result, result, msg(test.Input, test.ComparedTo))
+		result = comparedTo.Equals(input)
+		assert.Equal(t, expected, result, msg(test.Input, test.ComparedTo))
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 const (
 	// Version is the current version of Gort
-	Version = "0.7.7-dev.0"
+	Version = "0.7.8-dev.0"
 )


### PR DESCRIPTION
Implements rule condition parsing via the `rules.Parse` function. Makes heavy use of the `types` package -- especially types.Infer` -- under-the-covers.

The `types.Value` implementations have been simplified in the process.