### PR TITLE
v0.7.9-dev.1 Move role permission list logic to DAL; plus helpers and tests

### DIFF
--- a/data/rest/role-data.go
+++ b/data/rest/role-data.go
@@ -16,6 +16,8 @@
 
 package rest
 
+import "fmt"
+
 type Role struct {
 	Name        string
 	Permissions []RolePermission
@@ -24,4 +26,8 @@ type Role struct {
 type RolePermission struct {
 	BundleName string
 	Permission string
+}
+
+func (r RolePermission) String() string {
+	return fmt.Sprintf("%s:%s", r.BundleName, r.Permission)
 }

--- a/dataaccess/dataaccess.go
+++ b/dataaccess/dataaccess.go
@@ -67,8 +67,10 @@ type DataAccess interface {
 	RoleDelete(ctx context.Context, rolename string) error
 	RoleGet(ctx context.Context, rolename string) (rest.Role, error)
 	RoleExists(ctx context.Context, rolename string) (bool, error)
-	RoleGrantPermission(ctx context.Context, rolename, bundle, permission string) error
-	RoleRevokePermission(ctx context.Context, rolename, bundle, permission string) error
+	RoleGrantPermission(ctx context.Context, rolename, bundlename, permission string) error
+	RoleRevokePermission(ctx context.Context, rolename, bundlename, permission string) error
+	RoleHasPermission(ctx context.Context, rolename, bundlename, permission string) (bool, error)
+	RolePermissionList(ctx context.Context, rolename string) ([]rest.RolePermission, error)
 
 	TokenEvaluate(ctx context.Context, token string) bool
 	TokenGenerate(ctx context.Context, username string, duration time.Duration) (rest.Token, error)
@@ -86,5 +88,6 @@ type DataAccess interface {
 	UserGroupAdd(ctx context.Context, username string, groupname string) error
 	UserGroupDelete(ctx context.Context, username string, groupname string) error
 	UserList(ctx context.Context) ([]rest.User, error)
+	UserPermissions(ctx context.Context, username string) ([]string, error)
 	UserUpdate(ctx context.Context, user rest.User) error
 }

--- a/dataaccess/memory/group-access.go
+++ b/dataaccess/memory/group-access.go
@@ -18,6 +18,7 @@ package memory
 
 import (
 	"context"
+	"sort"
 
 	"github.com/getgort/gort/data/rest"
 	"github.com/getgort/gort/dataaccess/errs"
@@ -174,6 +175,8 @@ func (da *InMemoryDataAccess) GroupListRoles(ctx context.Context, groupname stri
 	for _, r := range gr {
 		roles = append(roles, *r)
 	}
+
+	sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
 
 	return roles, nil
 }

--- a/dataaccess/postgres/group-access.go
+++ b/dataaccess/postgres/group-access.go
@@ -311,7 +311,8 @@ func (da PostgresDataAccess) GroupListRoles(ctx context.Context, groupname strin
 
 	query := `SELECT role_name
 		FROM group_roles
-		WHERE group_name = $1`
+		WHERE group_name = $1
+		ORDER BY role_name`
 
 	rows, err := db.QueryContext(ctx, query, groupname)
 	if err != nil {

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -16,6 +16,8 @@
 
 package rules
 
+import "sort"
+
 type Rule struct {
 	Command     string
 	Conditions  []Expression
@@ -50,9 +52,10 @@ func (r Rule) Matches(env EvaluationEnvironment) bool {
 
 // Allowed returns true iff the user has all required permissions (or the rule
 // is an "allow" rule).
-func (r Rule) Allowed(permissions map[string]interface{}) bool {
+func (r Rule) Allowed(permissions []string) bool {
 	for _, required := range r.Permissions {
-		if _, ok := permissions[required]; !ok {
+		i := sort.SearchStrings(permissions, required)
+		if len(permissions) >= i || permissions[i] != required {
 			return false
 		}
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 const (
 	// Version is the current version of Gort
-	Version = "0.7.9-dev.0"
+	Version = "0.7.9-dev.1"
 )


### PR DESCRIPTION
Moved `getUserPermissions` logic from the Adapter to DAL where it belongs. Includes the following:

- `adapter. getUserPermissions` -> `dataaccess.da.UserPermissions` (in-memory and Postgres implementations)
- Found we needed `dataaccess.RoleHasPermission` and `dataaccess.RolePermissionList` methods. Added both (in-memory and Postgres implementations)
- Also needed and implemented stubbed `memory.UserGroup*` methods. 
- Discovered `postgres.UserGroupList` didn't work. Fixed and added tests.

_Observation: method names `dataaccess.RoleGrantPermission` and `dataaccess.RoleRevokePermission` are inconsistent. I think we should rename these to `dataaccess.RolePermissionAdd` and `dataaccess.RolePermissionDelete` for consistency._
