### PR TITLE
Make 'make test-local' generate test coverage profile HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@
 # Test binary, build with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
+# Output of the go coverage tool
 *.out
+
+# Output of `make test-local`, which runs `go tool cover -html=coverage.out -o coverage.html`
+coverage.html
 
 # Test files and typical binary names.
 test.yml

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ test:
 	@docker rmi foo_$(PROJECT)_foo
 
 test-local:
-	@go test -count=1 -timeout 60s -cover -race ./...
+	@go test -count=1 -timeout 60s -cover -race -coverprofile=coverage.out ./...
+	@go tool cover -html=coverage.out -o coverage.html
 
 build: clean
 	mkdir -p bin


### PR DESCRIPTION
The `make test-local` command now automatically generates a test coverage profile (`coverage.out`), and then generates an HTML representation of same (`coverage.html`).

Also `.gitignore` ignores both.