### PR TITLE
v0.7.9-dev.6 Rename/standardize DAL role/permission method names

### DIFF
--- a/dataaccess/dataaccess.go
+++ b/dataaccess/dataaccess.go
@@ -53,12 +53,12 @@ type DataAccess interface {
 	GroupDelete(ctx context.Context, groupname string) error
 	GroupExists(ctx context.Context, groupname string) (bool, error)
 	GroupGet(ctx context.Context, groupname string) (rest.Group, error)
-	GroupGrantRole(ctx context.Context, groupname, rolename string) error
 	GroupList(ctx context.Context) ([]rest.Group, error)
 	GroupListRoles(ctx context.Context, groupname string) ([]rest.Role, error)
 	GroupListUsers(ctx context.Context, groupname string) ([]rest.User, error)
 	GroupRemoveUser(ctx context.Context, groupname string, username string) error
-	GroupRevokeRole(ctx context.Context, groupname, rolename string) error
+	GroupRoleAdd(ctx context.Context, groupname, rolename string) error
+	GroupRoleDelete(ctx context.Context, groupname, rolename string) error
 	GroupUpdate(ctx context.Context, group rest.Group) error
 	GroupUserAdd(ctx context.Context, groupname string, username string) error
 	GroupUserDelete(ctx context.Context, groupname string, username string) error
@@ -67,9 +67,9 @@ type DataAccess interface {
 	RoleDelete(ctx context.Context, rolename string) error
 	RoleGet(ctx context.Context, rolename string) (rest.Role, error)
 	RoleExists(ctx context.Context, rolename string) (bool, error)
-	RoleGrantPermission(ctx context.Context, rolename, bundlename, permission string) error
-	RoleRevokePermission(ctx context.Context, rolename, bundlename, permission string) error
 	RoleHasPermission(ctx context.Context, rolename, bundlename, permission string) (bool, error)
+	RolePermissionAdd(ctx context.Context, rolename, bundlename, permission string) error
+	RolePermissionDelete(ctx context.Context, rolename, bundlename, permission string) error
 	RolePermissionList(ctx context.Context, rolename string) ([]rest.RolePermission, error)
 
 	TokenEvaluate(ctx context.Context, token string) bool

--- a/dataaccess/memory/group-access.go
+++ b/dataaccess/memory/group-access.go
@@ -126,8 +126,8 @@ func (da *InMemoryDataAccess) GroupGet(ctx context.Context, groupname string) (r
 	return *group, nil
 }
 
-// GroupGrantRole grants one or more roles to a group.
-func (da *InMemoryDataAccess) GroupGrantRole(ctx context.Context, groupname, rolename string) error {
+// GroupRoleAdd grants one or more roles to a group.
+func (da *InMemoryDataAccess) GroupRoleAdd(ctx context.Context, groupname, rolename string) error {
 	b, err := da.GroupExists(ctx, groupname)
 	if err != nil {
 		return err
@@ -211,8 +211,8 @@ func (da *InMemoryDataAccess) GroupRemoveUser(ctx context.Context, groupname str
 	return errs.ErrNoSuchUser
 }
 
-// GroupRevokeRole revokes one or more roles from a group.
-func (da *InMemoryDataAccess) GroupRevokeRole(ctx context.Context, groupname, rolename string) error {
+// GroupRoleDelete revokes one or more roles from a group.
+func (da *InMemoryDataAccess) GroupRoleDelete(ctx context.Context, groupname, rolename string) error {
 	b, err := da.GroupExists(ctx, groupname)
 	if err != nil {
 		return err

--- a/dataaccess/memory/group-access_test.go
+++ b/dataaccess/memory/group-access_test.go
@@ -30,7 +30,7 @@ func testGroupAccess(t *testing.T) {
 	t.Run("testGroupDelete", testGroupDelete)
 	t.Run("testGroupExists", testGroupExists)
 	t.Run("testGroupGet", testGroupGet)
-	t.Run("testGroupGrantRole", testGroupGrantRole)
+	t.Run("testGroupRoleAdd", testGroupRoleAdd)
 	t.Run("testGroupList", testGroupList)
 	t.Run("testGroupListRoles", testGroupListRoles)
 	t.Run("testGroupRemoveUser", testGroupRemoveUser)
@@ -156,7 +156,7 @@ func testGroupGet(t *testing.T) {
 	}
 }
 
-func testGroupGrantRole(t *testing.T) {
+func testGroupRoleAdd(t *testing.T) {
 	var err error
 
 	groupName := "group-group-grant-role"
@@ -172,12 +172,12 @@ func testGroupGrantRole(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, roleName, bundleName, permissionName)
+	err = da.RolePermissionAdd(ctx, roleName, bundleName, permissionName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 
-	err = da.GroupGrantRole(ctx, groupName, roleName)
+	err = da.GroupRoleAdd(ctx, groupName, roleName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -196,7 +196,7 @@ func testGroupGrantRole(t *testing.T) {
 
 	assert.Equal(t, expectedRoles, roles)
 
-	err = da.GroupRevokeRole(ctx, groupName, roleName)
+	err = da.GroupRoleDelete(ctx, groupName, roleName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -255,15 +255,15 @@ func testGroupListRoles(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-1")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-0")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-0")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-2")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/dataaccess/memory/role-access.go
+++ b/dataaccess/memory/role-access.go
@@ -76,7 +76,7 @@ func (da *InMemoryDataAccess) RoleGet(ctx context.Context, name string) (rest.Ro
 	return *role, nil
 }
 
-func (da *InMemoryDataAccess) RoleGrantPermission(ctx context.Context, rolename, bundlename, permission string) error {
+func (da *InMemoryDataAccess) RolePermissionAdd(ctx context.Context, rolename, bundlename, permission string) error {
 	role, ok := da.roles[rolename]
 
 	if !ok {
@@ -87,7 +87,7 @@ func (da *InMemoryDataAccess) RoleGrantPermission(ctx context.Context, rolename,
 	return nil
 }
 
-func (da *InMemoryDataAccess) RoleRevokePermission(ctx context.Context, rolename, bundlename, permission string) error {
+func (da *InMemoryDataAccess) RolePermissionDelete(ctx context.Context, rolename, bundlename, permission string) error {
 	role, ok := da.roles[rolename]
 
 	if !ok {

--- a/dataaccess/memory/role-access_test.go
+++ b/dataaccess/memory/role-access_test.go
@@ -114,13 +114,13 @@ func testRoleGet(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "test-get", "foo", "bar")
+	err = da.RolePermissionAdd(ctx, "test-get", "foo", "bar")
 	assert.NoError(t, err)
 
-	err = da.RoleGrantPermission(ctx, "test-get", "foo", "bat")
+	err = da.RolePermissionAdd(ctx, "test-get", "foo", "bat")
 	assert.NoError(t, err)
 
-	err = da.RoleRevokePermission(ctx, "test-get", "foo", "bat")
+	err = da.RolePermissionDelete(ctx, "test-get", "foo", "bat")
 	assert.NoError(t, err)
 
 	expected := rest.Role{
@@ -145,11 +145,11 @@ func testRoleHasPermission(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
+	err = da.RolePermissionAdd(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
+	defer da.RolePermissionDelete(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 
 	has, err = da.RoleHasPermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 	if !assert.NoError(t, err) || !assert.True(t, has) {
@@ -168,23 +168,23 @@ func testRolePermissionList(t *testing.T) {
 	da.RoleCreate(ctx, "role-test-role-permission-list")
 	defer da.RoleDelete(ctx, "role-test-role-permission-list")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
 
 	// Expect a sorted list!
 	expect := []rest.RolePermission{

--- a/dataaccess/memory/user-access_test.go
+++ b/dataaccess/memory/user-access_test.go
@@ -262,20 +262,20 @@ func testUserPermissions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "test-perms", "test-perms")
+	err = da.GroupRoleAdd(ctx, "test-perms", "test-perms")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-1")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-2")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-0")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-0")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/dataaccess/postgres/group-access.go
+++ b/dataaccess/postgres/group-access.go
@@ -209,10 +209,10 @@ func (da PostgresDataAccess) GroupGet(ctx context.Context, groupname string) (re
 	return group, nil
 }
 
-// GroupGrantRole grants one or more roles to a group.
-func (da PostgresDataAccess) GroupGrantRole(ctx context.Context, groupname, rolename string) error {
+// GroupRoleAdd grants one or more roles to a group.
+func (da PostgresDataAccess) GroupRoleAdd(ctx context.Context, groupname, rolename string) error {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
-	ctx, sp := tr.Start(ctx, "postgres.GroupGrantRole")
+	ctx, sp := tr.Start(ctx, "postgres.GroupRoleAdd")
 	defer sp.End()
 
 	if rolename == "" {
@@ -414,10 +414,10 @@ func (da PostgresDataAccess) GroupRemoveUser(ctx context.Context, groupname stri
 	return err
 }
 
-// GroupRevokeRole revokes a role from a group.
-func (da PostgresDataAccess) GroupRevokeRole(ctx context.Context, groupname, rolename string) error {
+// GroupRoleDelete revokes a role from a group.
+func (da PostgresDataAccess) GroupRoleDelete(ctx context.Context, groupname, rolename string) error {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
-	ctx, sp := tr.Start(ctx, "postgres.GroupRevokeRole")
+	ctx, sp := tr.Start(ctx, "postgres.GroupRoleDelete")
 	defer sp.End()
 
 	if groupname == "" {

--- a/dataaccess/postgres/group-access_test.go
+++ b/dataaccess/postgres/group-access_test.go
@@ -30,7 +30,7 @@ func testGroupAccess(t *testing.T) {
 	t.Run("testGroupDelete", testGroupDelete)
 	t.Run("testGroupExists", testGroupExists)
 	t.Run("testGroupGet", testGroupGet)
-	t.Run("testGroupGrantRole", testGroupGrantRole)
+	t.Run("testGroupRoleAdd", testGroupRoleAdd)
 	t.Run("testGroupList", testGroupList)
 	t.Run("testGroupListRoles", testGroupListRoles)
 	t.Run("testGroupRemoveUser", testGroupRemoveUser)
@@ -156,7 +156,7 @@ func testGroupGet(t *testing.T) {
 	}
 }
 
-func testGroupGrantRole(t *testing.T) {
+func testGroupRoleAdd(t *testing.T) {
 	var err error
 
 	groupName := "group-group-grant-role"
@@ -172,12 +172,12 @@ func testGroupGrantRole(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, roleName, bundleName, permissionName)
+	err = da.RolePermissionAdd(ctx, roleName, bundleName, permissionName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 
-	err = da.GroupGrantRole(ctx, groupName, roleName)
+	err = da.GroupRoleAdd(ctx, groupName, roleName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -196,7 +196,7 @@ func testGroupGrantRole(t *testing.T) {
 
 	assert.Equal(t, expectedRoles, roles)
 
-	err = da.GroupRevokeRole(ctx, groupName, roleName)
+	err = da.GroupRoleDelete(ctx, groupName, roleName)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -255,15 +255,15 @@ func testGroupListRoles(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-1")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-0")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-0")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "group-test-group-list-roles", "role-test-group-list-roles-2")
+	err = da.GroupRoleAdd(ctx, "group-test-group-list-roles", "role-test-group-list-roles-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/dataaccess/postgres/role-access.go
+++ b/dataaccess/postgres/role-access.go
@@ -165,9 +165,9 @@ func (da PostgresDataAccess) RoleGet(ctx context.Context, name string) (rest.Rol
 	return role, nil
 }
 
-func (da PostgresDataAccess) RoleGrantPermission(ctx context.Context, rolename, bundle, permission string) error {
+func (da PostgresDataAccess) RolePermissionAdd(ctx context.Context, rolename, bundle, permission string) error {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
-	ctx, sp := tr.Start(ctx, "postgres.RoleGrantPermission")
+	ctx, sp := tr.Start(ctx, "postgres.RolePermissionAdd")
 	defer sp.End()
 
 	if rolename == "" {
@@ -206,9 +206,9 @@ func (da PostgresDataAccess) RoleGrantPermission(ctx context.Context, rolename, 
 	return err
 }
 
-func (da PostgresDataAccess) RoleRevokePermission(ctx context.Context, rolename, bundle, permission string) error {
+func (da PostgresDataAccess) RolePermissionDelete(ctx context.Context, rolename, bundle, permission string) error {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
-	ctx, sp := tr.Start(ctx, "postgres.RoleRevokePermission")
+	ctx, sp := tr.Start(ctx, "postgres.RolePermissionDelete")
 	defer sp.End()
 
 	if rolename == "" {

--- a/dataaccess/postgres/role-access_test.go
+++ b/dataaccess/postgres/role-access_test.go
@@ -114,13 +114,13 @@ func testRoleGet(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "test-get", "foo", "bar")
+	err = da.RolePermissionAdd(ctx, "test-get", "foo", "bar")
 	assert.NoError(t, err)
 
-	err = da.RoleGrantPermission(ctx, "test-get", "foo", "bat")
+	err = da.RolePermissionAdd(ctx, "test-get", "foo", "bat")
 	assert.NoError(t, err)
 
-	err = da.RoleRevokePermission(ctx, "test-get", "foo", "bat")
+	err = da.RolePermissionDelete(ctx, "test-get", "foo", "bat")
 	assert.NoError(t, err)
 
 	expected := rest.Role{
@@ -145,11 +145,11 @@ func testRoleHasPermission(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
+	err = da.RolePermissionAdd(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
+	defer da.RolePermissionDelete(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 
 	has, err = da.RoleHasPermission(ctx, "role-test-role-has-permission", "test", "permission-test-role-has-permission-1")
 	if !assert.NoError(t, err) || !assert.True(t, has) {
@@ -168,23 +168,23 @@ func testRolePermissionList(t *testing.T) {
 	da.RoleCreate(ctx, "role-test-role-permission-list")
 	defer da.RoleDelete(ctx, "role-test-role-permission-list")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-1")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-3")
 
-	err = da.RoleGrantPermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
+	err = da.RolePermissionAdd(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	defer da.RoleRevokePermission(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
+	defer da.RolePermissionDelete(ctx, "role-test-role-permission-list", "test", "permission-test-role-permission-list-2")
 
 	// Expect a sorted list!
 	expect := []rest.RolePermission{

--- a/dataaccess/postgres/user-access_test.go
+++ b/dataaccess/postgres/user-access_test.go
@@ -262,20 +262,20 @@ func testUserPermissions(t *testing.T) {
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.GroupGrantRole(ctx, "test-perms", "test-perms")
+	err = da.GroupRoleAdd(ctx, "test-perms", "test-perms")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
 
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-1")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-1")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-2")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-2")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	err = da.RoleGrantPermission(ctx, "test-perms", "test", "test-perms-0")
+	err = da.RolePermissionAdd(ctx, "test-perms", "test", "test-perms-0")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/service/group-handlers.go
+++ b/service/group-handlers.go
@@ -102,7 +102,7 @@ func handleDeleteGroupRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dataAccessLayer.GroupRevokeRole(r.Context(), groupname, rolename)
+	err = dataAccessLayer.GroupRoleDelete(r.Context(), groupname, rolename)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 	}
@@ -288,7 +288,7 @@ func handlePutGroupRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dataAccessLayer.GroupGrantRole(r.Context(), groupname, rolename)
+	err = dataAccessLayer.GroupRoleAdd(r.Context(), groupname, rolename)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 	}

--- a/service/role-handlers.go
+++ b/service/role-handlers.go
@@ -76,7 +76,7 @@ func handleGrantRolePermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dataAccessLayer.RoleGrantPermission(r.Context(), rolename, bundlename, permissionname)
+	err = dataAccessLayer.RolePermissionAdd(r.Context(), rolename, bundlename, permissionname)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -100,7 +100,7 @@ func handleRevokeRolePermission(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dataAccessLayer.RoleRevokePermission(r.Context(), rolename, bundlename, permissionname)
+	err = dataAccessLayer.RolePermissionDelete(r.Context(), rolename, bundlename, permissionname)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return

--- a/service/service.go
+++ b/service/service.go
@@ -346,7 +346,7 @@ func handleBootstrap(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Add role to group
-	err = dataAccessLayer.GroupGrantRole(r.Context(), adminGroup, adminRole)
+	err = dataAccessLayer.GroupRoleAdd(r.Context(), adminGroup, adminRole)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -354,7 +354,7 @@ func handleBootstrap(w http.ResponseWriter, r *http.Request) {
 
 	// Add the default permissions.
 	for _, p := range adminPermissions {
-		err = dataAccessLayer.RoleGrantPermission(r.Context(), adminRole, "gort", p)
+		err = dataAccessLayer.RolePermissionAdd(r.Context(), adminRole, "gort", p)
 		if err != nil {
 			respondAndLogError(r.Context(), w, err)
 			return

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 const (
 	// Version is the current version of Gort
-	Version = "0.7.9-dev.5"
+	Version = "0.7.9-dev.6"
 )


### PR DESCRIPTION
Per title: standardizing DAL method names for consistency. They're now divergent from the CLI commands, but I think that's okay.