### PR TITLE
v0.7.10-dev.0 Add RBAC to service endpoints

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -463,7 +463,7 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 		return nil, fmt.Errorf("user permission load error: %w", err)
 	}
 
-	allowed, err := auth.Evaluate(ctx, perms, cmdEntry, env)
+	allowed, err := auth.EvaluateCommandEntry(perms, cmdEntry, env)
 	if err != nil {
 		da.RequestError(ctx, request, err)
 		telemetry.Errors().WithError(err).Commit(ctx)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -17,7 +17,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -29,9 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEvaluate(t *testing.T) {
-	ctx := context.Background()
-
+func TestEvaluateCommandEntry(t *testing.T) {
 	b, err := bundles.LoadBundle("../testing/test-bundle-foo.yml")
 	if err != nil {
 		t.Error(err.Error())
@@ -40,26 +37,24 @@ func TestEvaluate(t *testing.T) {
 	envFooTrue := rules.EvaluationEnvironment{"option": map[string]types.Value{"foo": types.BoolValue{V: true}}}
 	envFooFalse := rules.EvaluationEnvironment{"option": map[string]types.Value{}}
 
-	result, err := Evaluate(ctx, []string{}, cmd, envFooFalse)
+	result, err := EvaluateCommandEntry([]string{}, cmd, envFooFalse)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
-	result, err = Evaluate(ctx, []string{"test:foo"}, cmd, envFooFalse)
+	result, err = EvaluateCommandEntry([]string{"test:foo"}, cmd, envFooFalse)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
-	result, err = Evaluate(ctx, []string{}, cmd, envFooTrue)
+	result, err = EvaluateCommandEntry([]string{}, cmd, envFooTrue)
 	assert.NoError(t, err)
 	assert.False(t, result)
 
-	result, err = Evaluate(ctx, []string{"test:foo"}, cmd, envFooTrue)
+	result, err = EvaluateCommandEntry([]string{"test:foo"}, cmd, envFooTrue)
 	assert.NoError(t, err)
 	assert.True(t, result)
 }
 
-func TestEvaluate2(t *testing.T) {
-	ctx := context.Background()
-
+func TestEvaluateCommandEntry2(t *testing.T) {
 	b, err := bundles.LoadBundle("../testing/test-default.yml")
 	if err != nil {
 		t.Error(err.Error())
@@ -69,11 +64,11 @@ func TestEvaluate2(t *testing.T) {
 	assert.NoError(t, err)
 	cmdE := data.CommandEntry{Bundle: b, Command: *b.Commands[cmd.Command]}
 
-	result, err := Evaluate(ctx, []string{"test:foo", "gort:manage_users"}, cmdE, env)
+	result, err := EvaluateCommandEntry([]string{"test:foo", "gort:manage_users"}, cmdE, env)
 	assert.NoError(t, err)
 	assert.True(t, result)
 
-	result, err = Evaluate(ctx, []string{"test:foo"}, cmdE, env)
+	result, err = EvaluateCommandEntry([]string{"test:foo"}, cmdE, env)
 	assert.NoError(t, err)
 	assert.False(t, result)
 }

--- a/cli/group-create.go
+++ b/cli/group-create.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	groupCreateUse   = "create"
-	groupCreateShort = "Create an existing group"
-	groupCreateLong  = "Create an existing group."
+	groupCreateShort = "Create a new group"
+	groupCreateLong  = "Create a new group."
 )
 
 // GetGroupCreateCmd is a command

--- a/dataaccess/postgres/bundle-access.go
+++ b/dataaccess/postgres/bundle-access.go
@@ -219,8 +219,9 @@ func (da PostgresDataAccess) BundleEnable(ctx context.Context, name, version str
 	return nil
 }
 
-// BundleEnabledVersion TBD
-func (da PostgresDataAccess) BundleEnabledVersion(ctx context.Context, name string) (string, error) {
+// BundleEnabledVersion returns the currently enabled version of the specified bundle.
+// If no version is enabled an empty string will be returned.
+func (da PostgresDataAccess) BundleEnabledVersion(ctx context.Context, bundlename string) (string, error) {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
 	ctx, sp := tr.Start(ctx, "postgres.BundleEnabledVersion")
 	defer sp.End()
@@ -236,7 +237,7 @@ func (da PostgresDataAccess) BundleEnabledVersion(ctx context.Context, name stri
 		return "", gerr.Wrap(errs.ErrDataAccess, err)
 	}
 
-	enabled, err := da.doBundleEnabledVersion(ctx, tx, name)
+	enabled, err := da.doBundleEnabledVersion(ctx, tx, bundlename)
 	if err != nil {
 		tx.Rollback()
 		return "", gerr.Wrap(errs.ErrDataAccess, err)

--- a/rules/parse.go
+++ b/rules/parse.go
@@ -117,3 +117,19 @@ func ParseExpression(expr string) (a, b string, o Operator, m CollectionOperatio
 
 	return
 }
+
+// TokenizeAndParse is a helper function that wraps the Tokenize and Parse
+// functions. It accepts a raw Gort rule of the form "COMMAND [when CONDITION
+// (and|or)]? [allow|must have PERMISSION (and|or)]", and returns a RuleTokens
+// value. A parsing error will produce a non-nil error. The RuleTokens' Command
+// value should always be non-empty; Conditions and Permissions can both be
+// empty (but non-nil). Empty Conditions always match the command. Empty
+// Permissions indicating the use of the "allow" keyword and always pass.
+func TokenizeAndParse(s string) (Rule, error) {
+	rt, err := Tokenize(s)
+	if err != nil {
+		return Rule{}, err
+	}
+
+	return Parse(rt)
+}

--- a/service/bundle-handlers.go
+++ b/service/bundle-handlers.go
@@ -202,15 +202,15 @@ func getAllBundles(ctx context.Context) ([]data.Bundle, error) {
 }
 
 func addBundleMethodsToRouter(router *mux.Router) {
-	router.Handle("/v2/bundles", otelhttp.NewHandler(http.HandlerFunc(handleGetBundles), "handleGetBundles")).Methods("GET")
+	router.Handle("/v2/bundles", otelhttp.NewHandler(authCommand(handleGetBundles, "bundle", "info"), "handleGetBundles")).Methods("GET")
 
-	router.Handle("/v2/bundles/{name}", otelhttp.NewHandler(http.HandlerFunc(handleGetBundleVersions), "handleGetBundleVersions")).Methods("GET")
-	router.Handle("/v2/bundles/{name}/versions", otelhttp.NewHandler(http.HandlerFunc(handleGetBundleVersions), "handleGetBundleVersions")).Methods("GET")
+	router.Handle("/v2/bundles/{name}", otelhttp.NewHandler(authCommand(handleGetBundleVersions, "bundle", "info"), "handleGetBundleVersions")).Methods("GET")
+	router.Handle("/v2/bundles/{name}/versions", otelhttp.NewHandler(authCommand(handleGetBundleVersions, "bundle", "list"), "handleGetBundleVersions")).Methods("GET")
 
-	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(http.HandlerFunc(handleGetBundleVersion), "handleGetBundleVersion")).Methods("GET")
-	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(http.HandlerFunc(handlePutBundleVersion), "handlePutBundleVersion")).Methods("PUT")
-	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteBundleVersion), "handleDeleteBundleVersion")).Methods("DELETE")
+	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(authCommand(handleGetBundleVersion, "bundle", "info"), "handleGetBundleVersion")).Methods("GET")
+	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(authCommand(handlePutBundleVersion, "bundle", "install"), "handlePutBundleVersion")).Methods("PUT")
+	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(authCommand(handleDeleteBundleVersion, "bundle", "install"), "handleDeleteBundleVersion")).Methods("DELETE")
 
-	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(http.HandlerFunc(handlePatchBundleVersion), "handlePatchBundleVersion")).Methods("PATCH")
-	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(http.HandlerFunc(handlePatchBundleVersion), "handlePatchBundleVersion")).Methods("PATCH").Queries("enabled", "")
+	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(authCommand(handlePatchBundleVersion, "bundle", "enable"), "handlePatchBundleVersion")).Methods("PATCH")
+	router.Handle("/v2/bundles/{name}/versions/{version}", otelhttp.NewHandler(authCommand(handlePatchBundleVersion, "bundle", "enable"), "handlePatchBundleVersion")).Methods("PATCH").Queries("enabled", "")
 }

--- a/service/group-handlers.go
+++ b/service/group-handlers.go
@@ -296,18 +296,18 @@ func handlePutGroupRole(w http.ResponseWriter, r *http.Request) {
 
 func addGroupMethodsToRouter(router *mux.Router) {
 	// Basic group methods
-	router.Handle("/v2/groups", otelhttp.NewHandler(http.HandlerFunc(handleGetGroups), "handleGetGroups")).Methods("GET")
-	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(http.HandlerFunc(handleGetGroup), "handleGetGroup")).Methods("GET")
-	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(http.HandlerFunc(handlePutGroup), "handlePutGroup")).Methods("PUT")
-	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteGroup), "handleDeleteGroup")).Methods("DELETE")
+	router.Handle("/v2/groups", otelhttp.NewHandler(authCommand(handleGetGroups, "group", "list"), "handleGetGroups")).Methods("GET")
+	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(authCommand(handleGetGroup, "group", "info"), "handleGetGroup")).Methods("GET")
+	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(authCommand(handlePutGroup, "group", "create"), "handlePutGroup")).Methods("PUT")
+	router.Handle("/v2/groups/{groupname}", otelhttp.NewHandler(authCommand(handleDeleteGroup, "group", "delete"), "handleDeleteGroup")).Methods("DELETE")
 
 	// Group user membership
-	router.Handle("/v2/groups/{groupname}/members", otelhttp.NewHandler(http.HandlerFunc(handleGetGroupMembers), "handleGetGroupMembers")).Methods("GET")
-	router.Handle("/v2/groups/{groupname}/members/{username}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteGroupMember), "handleDeleteGroupMember")).Methods("DELETE")
-	router.Handle("/v2/groups/{groupname}/members/{username}", otelhttp.NewHandler(http.HandlerFunc(handlePutGroupMember), "handlePutGroupMember")).Methods("PUT")
+	router.Handle("/v2/groups/{groupname}/members", otelhttp.NewHandler(authCommand(handleGetGroupMembers, "group", ""), "handleGetGroupMembers")).Methods("GET")
+	router.Handle("/v2/groups/{groupname}/members/{username}", otelhttp.NewHandler(authCommand(handleDeleteGroupMember, "group", ""), "handleDeleteGroupMember")).Methods("DELETE")
+	router.Handle("/v2/groups/{groupname}/members/{username}", otelhttp.NewHandler(authCommand(handlePutGroupMember, "group", ""), "handlePutGroupMember")).Methods("PUT")
 
 	// Group roles
-	router.Handle("/v2/groups/{groupname}/roles", otelhttp.NewHandler(http.HandlerFunc(handleGetGroupRoles), "handleGetGroupMembers")).Methods("GET")
-	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteGroupRole), "handleDeleteGroupMember")).Methods("DELETE")
-	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(http.HandlerFunc(handlePutGroupRole), "handlePutGroupMember")).Methods("PUT")
+	router.Handle("/v2/groups/{groupname}/roles", otelhttp.NewHandler(authCommand(handleGetGroupRoles, "group", "info"), "handleGetGroupMembers")).Methods("GET")
+	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handleDeleteGroupRole, "group", "add"), "handleDeleteGroupMember")).Methods("DELETE")
+	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handlePutGroupRole, "group", "add"), "handlePutGroupMember")).Methods("PUT")
 }

--- a/service/role-handlers.go
+++ b/service/role-handlers.go
@@ -121,11 +121,11 @@ func handlePutRole(w http.ResponseWriter, r *http.Request) {
 
 func addRoleMethodsToRouter(router *mux.Router) {
 	// Basic role methods
-	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(http.HandlerFunc(handleGetRole), "handleGetRole")).Methods("GET")
-	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(http.HandlerFunc(handlePutRole), "handlePutRole")).Methods("PUT")
-	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteRole), "handleDeleteRole")).Methods("DELETE")
+	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(authCommand(handleGetRole, "role", "create"), "handleGetRole")).Methods("GET")
+	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(authCommand(handlePutRole, "role", "create"), "handlePutRole")).Methods("PUT")
+	router.Handle("/v2/roles/{rolename}", otelhttp.NewHandler(authCommand(handleDeleteRole, "role", "delete"), "handleDeleteRole")).Methods("DELETE")
 
 	// Role permissions
-	router.Handle("/v2/roles/{rolename}/bundles/{bundlename}/permissions/{permissionname}", otelhttp.NewHandler(http.HandlerFunc(handleRevokeRolePermission), "handleDeleteRolePermission")).Methods("DELETE")
-	router.Handle("/v2/roles/{rolename}/bundles/{bundlename}/permissions/{permissionname}", otelhttp.NewHandler(http.HandlerFunc(handleGrantRolePermission), "handlePutRolePermission")).Methods("PUT")
+	router.Handle("/v2/roles/{rolename}/bundles/{bundlename}/permissions/{permissionname}", otelhttp.NewHandler(authCommand(handleRevokeRolePermission, "role", "revoke-permission"), "handleDeleteRolePermission")).Methods("DELETE")
+	router.Handle("/v2/roles/{rolename}/bundles/{bundlename}/permissions/{permissionname}", otelhttp.NewHandler(authCommand(handleGrantRolePermission, "role", "grant-permission"), "handlePutRolePermission")).Methods("PUT")
 }

--- a/service/user-handlers.go
+++ b/service/user-handlers.go
@@ -139,13 +139,13 @@ func handlePutUserGroup(w http.ResponseWriter, r *http.Request) {
 }
 
 func addUserMethodsToRouter(router *mux.Router) {
-	router.Handle("/v2/users", otelhttp.NewHandler(http.HandlerFunc(handleGetUsers), "handleGetUsers")).Methods("GET")
-	router.Handle("/v2/users/{username}", otelhttp.NewHandler(http.HandlerFunc(handleGetUser), "handleGetUser")).Methods("GET")
-	router.Handle("/v2/users/{username}", otelhttp.NewHandler(http.HandlerFunc(handlePutUser), "handlePutUser")).Methods("PUT")
-	router.Handle("/v2/users/{username}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteUser), "handleDeleteUser")).Methods("DELETE")
+	router.Handle("/v2/users", otelhttp.NewHandler(authCommand(handleGetUsers, "user", "info"), "handleGetUsers")).Methods("GET")
+	router.Handle("/v2/users/{username}", otelhttp.NewHandler(authCommand(handleGetUser, "user", "info"), "handleGetUser")).Methods("GET")
+	router.Handle("/v2/users/{username}", otelhttp.NewHandler(authCommand(handlePutUser, "user", "update"), "handlePutUser")).Methods("PUT")
+	router.Handle("/v2/users/{username}", otelhttp.NewHandler(authCommand(handleDeleteUser, "user", "delete"), "handleDeleteUser")).Methods("DELETE")
 
 	// User group membership
-	router.Handle("/v2/users/{username}/groups", otelhttp.NewHandler(http.HandlerFunc(handleGetUserGroups), "handleGetUserGroups")).Methods("GET")
-	router.Handle("/v2/users/{username}/groups/{username}", otelhttp.NewHandler(http.HandlerFunc(handleDeleteUserGroup), "handleDeleteUserGroup")).Methods("DELETE")
-	router.Handle("/v2/users/{username}/groups/{username}", otelhttp.NewHandler(http.HandlerFunc(handlePutUserGroup), "handlePutUserGroup")).Methods("PUT")
+	router.Handle("/v2/users/{username}/groups", otelhttp.NewHandler(authCommand(handleGetUserGroups, "user", "info"), "handleGetUserGroups")).Methods("GET")
+	router.Handle("/v2/users/{username}/groups/{username}", otelhttp.NewHandler(authCommand(handleDeleteUserGroup, "user", "update"), "handleDeleteUserGroup")).Methods("DELETE")
+	router.Handle("/v2/users/{username}/groups/{username}", otelhttp.NewHandler(authCommand(handlePutUserGroup, "user", "update"), "handlePutUserGroup")).Methods("PUT")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 const (
 	// Version is the current version of Gort
-	Version = "0.7.9-dev.6"
+	Version = "0.7.10-dev.0"
 )


### PR DESCRIPTION
Added RBAC to service API endpoints. In this scheme, each endpoint maps to a literal subcommand in the default Gort command bundle, and uses the permissions assigned there to determine whether a user is allowed to invoke a given endpoint.

Also updated service tests to include a token for testing purposes.