### PR TITLE
Fix "partial output" bug

### DIFF
--- a/data/config.go
+++ b/data/config.go
@@ -16,6 +16,8 @@
 
 package data
 
+import "time"
+
 // GortConfig is the top-level configuration object
 type GortConfig struct {
 	GortServerConfigs GortServerConfigs `yaml:"gort,omitempty"`
@@ -41,6 +43,10 @@ type GortServerConfigs struct {
 // GlobalConfigs is the data wrapper for the "global" section
 type GlobalConfigs struct {
 	CommandTimeoutSeconds int `yaml:"command_timeout_seconds,omitempty"`
+}
+
+func (c GlobalConfigs) CommandTimeout() time.Duration {
+	return time.Duration(c.CommandTimeoutSeconds) * time.Second
 }
 
 // DatabaseConfigs is the data wrapper for the "database" section.

--- a/dataaccess/dal-singleton.go
+++ b/dataaccess/dal-singleton.go
@@ -57,6 +57,8 @@ var (
 	currentState State
 	stateMutex   = sync.Mutex{}
 
+	initializationMutex = sync.Mutex{}
+
 	stateChangeListeners      []chan State
 	stateChangeListenersMutex = sync.RWMutex{}
 
@@ -133,10 +135,14 @@ func getCorrectDataAccess() DataAccess {
 // initializeDataAccess is called by monitorConfig to initialize the data
 // access layer whenever the configuration is updated.
 func initializeDataAccess(ctx context.Context) {
+	initializationMutex.Lock()
+
 	// Ignore current status
 	<-configUpdates
 
 	go func() {
+		defer initializationMutex.Unlock()
+
 		delay := time.Second
 
 		updateDALState(StateInitializing)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   gort:
     image: getgort/gort:latest
-    command: "gort start -v"
+    command: "start -v"
     ports:
       - "4000:4000"
     volumes:

--- a/version/version.go
+++ b/version/version.go
@@ -18,5 +18,5 @@ package version
 
 const (
 	// Version is the current version of Gort
-	Version = "0.8.0-alpha.0"
+	Version = "0.8.0-alpha.1"
 )


### PR DESCRIPTION
Fixes the "partial output" bug reported by https://github.com/getgort/gort/issues/38. The problem turned out to be a context cancellation that was called by a defer in an async function, which meant the worker container was being canceled almost immediately.

Also did some cleanup and commenting while I was in there.
