### PR TITLE
Use durations in config; allow configuration of supported PGSQL parameters

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,9 @@
 global:
-  # How long before a command times out, in seconds.
+  # How long before a command times out. Accepts a duration string: a sequence
+  # of decimal numbers, each with optional fraction and a unit suffix: 1d,
+  # 1h30m, 5m, 10s. Valid units are "ms", "s", "m", "h". Defaults to 60s.
   # TODO Allow overriding at the command level
-  command_timeout_seconds: 60
+  command_timeout: 60s
 
 gort:
   # Gort will automatically create accounts for new users when set.
@@ -53,16 +55,33 @@ database:
   # Defaults to false.
   ssl_enabled: true
 
-  # Database connection pool size. Defaults to 10.
-  pool_size: 10
+  # The maximum amount of time a connection may be idle. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's idle time. Defaults to 1m.
+  connection_max_idle_time: 0s
 
-  # Number of milliseconds to wait to checkout a database connection from the pool.
-  # Defaults to 15000 ms.
-  pool_timeout: 15000
+  # The maximum amount of time a connection may be reused. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's age. Defaults to 10m
+  connection_max_life_time: 0s
 
-  # Amount of time to wait for execution of a database query to complete.
-  # Defaults to 15000 ms.
-  query_timeout: 15000
+  # Sets the maximum number of connections in the idle connection pool. If
+  # max_open_connections is > 0 but < max_idle_connections, then this value
+  # will be reduced to match max_open_connections.
+  # If n <= 0, no idle connections are retained.
+  # Defaults to 2
+  max_idle_connections: 2
+
+  # The maximum number of open connections to the database. If
+  # max_idle_connections is > 0 and the new this is less than
+  # max_idle_connections, then max_idle_connections will be reduced to match
+  # this value. If n <= 0, then there is no limit on the number of open
+  # connections. The default is 0 (unlimited).
+  max_open_connections: 0
+
+  # How long to wait for execution of a database query to complete.
+  # Defaults to 15s.
+  query_timeout: 15s
 
 # Move this to the relay config later.
 docker:

--- a/config/config.go
+++ b/config/config.go
@@ -261,7 +261,7 @@ func loadConfiguration(file string) (*data.GortConfig, error) {
 	return &config, nil
 }
 
-//  reloadConfiguration is called by both BeginChangeCheck() and Initialize()
+// reloadConfiguration is called by both BeginChangeCheck() and Initialize()
 // to determine whether the config file has changed (or is new) and reload if
 // it has.
 func reloadConfiguration() error {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,7 @@ package config
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/getgort/gort/data"
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,7 @@ func TestLoadConfiguration(t *testing.T) {
 
 	cglobal := config.GlobalConfigs
 	assert.NotNil(t, cglobal)
-	assert.Equal(t, 60, cglobal.CommandTimeoutSeconds)
+	assert.Equal(t, time.Minute, cglobal.CommandTimeout)
 
 	cgort := config.GortServerConfigs
 	assert.NotNil(t, cgort)
@@ -50,9 +51,11 @@ func TestLoadConfiguration(t *testing.T) {
 	assert.Equal(t, "gort", cdb.User)
 	assert.Equal(t, "veryKleverPassw0rd!", cdb.Password)
 	assert.Equal(t, true, cdb.SSLEnabled)
-	assert.Equal(t, 10, cdb.PoolSize)
-	assert.Equal(t, 15000, cdb.PoolTimeout)
-	assert.Equal(t, 15000, cdb.QueryTimeout)
+
+	assert.Equal(t, 30*time.Second, cdb.ConnectionMaxIdleTime)
+	assert.Equal(t, 5*time.Minute, cdb.ConnectionMaxLifetime)
+	assert.Equal(t, 2, cdb.MaxIdleConnections)
+	assert.Equal(t, 4, cdb.MaxOpenConnections)
 
 	cd := config.DockerConfigs
 	assert.NotNil(t, cd)

--- a/data/config.go
+++ b/data/config.go
@@ -42,23 +42,21 @@ type GortServerConfigs struct {
 
 // GlobalConfigs is the data wrapper for the "global" section
 type GlobalConfigs struct {
-	CommandTimeoutSeconds int `yaml:"command_timeout_seconds,omitempty"`
-}
-
-func (c GlobalConfigs) CommandTimeout() time.Duration {
-	return time.Duration(c.CommandTimeoutSeconds) * time.Second
+	CommandTimeout time.Duration `yaml:"command_timeout,omitempty"`
 }
 
 // DatabaseConfigs is the data wrapper for the "database" section.
 type DatabaseConfigs struct {
-	Host         string `yaml:"host,omitempty"`
-	Port         int    `yaml:"port,omitempty"`
-	User         string `yaml:"user,omitempty"`
-	Password     string `yaml:"password,omitempty"`
-	SSLEnabled   bool   `yaml:"ssl_enabled,omitempty"`
-	PoolSize     int    `yaml:"pool_size,omitempty"`
-	PoolTimeout  int    `yaml:"pool_timeout,omitempty"`
-	QueryTimeout int    `yaml:"query_timeout,omitempty"`
+	Host                  string        `yaml:"host,omitempty"`
+	Port                  int           `yaml:"port,omitempty"`
+	User                  string        `yaml:"user,omitempty"`
+	Password              string        `yaml:"password,omitempty"`
+	SSLEnabled            bool          `yaml:"ssl_enabled,omitempty"`
+	ConnectionMaxIdleTime time.Duration `yaml:"connection_max_idle_time,omitempty"`
+	ConnectionMaxLifetime time.Duration `yaml:"connection_max_life_time,omitempty"`
+	MaxIdleConnections    int           `yaml:"max_idle_connections,omitempty"`
+	MaxOpenConnections    int           `yaml:"max_open_connections,omitempty"`
+	QueryTimeout          time.Duration `yaml:"query_timeout,omitempty"`
 }
 
 // DockerConfigs is the data wrapper for the "docker" section.

--- a/dataaccess/postgres/postgres-data-access.go
+++ b/dataaccess/postgres/postgres-data-access.go
@@ -106,6 +106,11 @@ func (da PostgresDataAccess) initializeGortData(ctx context.Context) error {
 	}
 	defer db.Close()
 
+	db.SetMaxIdleConns(da.configs.MaxIdleConnections)
+	db.SetMaxOpenConns(da.configs.MaxOpenConnections)
+	db.SetConnMaxIdleTime(da.configs.ConnectionMaxIdleTime)
+	db.SetConnMaxLifetime(da.configs.ConnectionMaxLifetime)
+
 	// Check whether the users table exists
 	exists, err := da.tableExists(ctx, "users", db)
 	if err != nil {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -23,7 +23,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 
-	"github.com/getgort/gort/config"
 	"github.com/getgort/gort/data"
 	"github.com/getgort/gort/data/rest"
 	"github.com/getgort/gort/dataaccess"
@@ -192,9 +191,9 @@ func runWorker(ctx context.Context, worker *worker.Worker, response data.Command
 	defer sp.End()
 
 	// Get configured timeout. Zero (or less) is no timeout.
-	timeout := config.GetGlobalConfigs().CommandTimeout()
+	timeout := worker.ExecutionTimeout
 	if timeout <= 0 {
-		timeout = time.Hour * 24 * 365 // No timeout? Just use one year.
+		timeout = time.Hour * 24 * 365 // No timeout? No problem.
 	}
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/testing/config/complete.yml
+++ b/testing/config/complete.yml
@@ -1,7 +1,9 @@
 global:
-  # How long before a command times out, in seconds.
+  # How long before a command times out. Accepts a duration string: a sequence
+  # of decimal numbers, each with optional fraction and a unit suffix: 1d,
+  # 1h30m, 5m, 10s. Valid units are "ms", "s", "m", "h".
   # TODO Allow overriding at the command level
-  command_timeout_seconds: 60
+  command_timeout: 60s
 
 gort:
   # Gort will automatically create accounts for new users when set.
@@ -28,12 +30,12 @@ gort:
 
   # If set along with tls_key_file, TLS will be used for API connections.
   # This parameter specifies the path to a certificate file.
-  # tls_cert_file: host.crt
+  tls_cert_file: host.crt
 
   # If set along with tls_cert_file, TLS will be used for API connections.
   # This parameter specifies the path to a key file.
   # The key must not be encrypted with a password.
-  # tls_key_file: host.key
+  tls_key_file: host.key
 
 database:
   # The host where Gort's PostgreSQL database lives. Defaults to localhost.
@@ -53,16 +55,32 @@ database:
   # Defaults to false.
   ssl_enabled: true
 
-  # Database connection pool size. Defaults to 10.
-  pool_size: 10
+  # The maximum amount of time a connection may be idle. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's idle time. Defaults to 1m.
+  connection_max_idle_time: 30s
 
-  # Number of milliseconds to wait to checkout a database connection from the pool.
-  # Defaults to 15000 ms.
-  pool_timeout: 15000
+  # The maximum amount of time a connection may be reused. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's age. Defaults to 10m
+  connection_max_life_time: 5m
 
-  # Amount of time to wait for execution of a database query to complete.
-  # Defaults to 15000 ms.
-  query_timeout: 15000
+  # Sets the maximum number of connections in the idle connection pool. If
+  # max_open_connections is > 0 but < max_idle_connections, then this value
+  # will be reduced to match max_open_connections.
+  # If n <= 0, no idle connections are retained. Defaults to 2
+  max_idle_connections: 2
+
+  # The maximum number of open connections to the database. If
+  # max_idle_connections is > 0 and the new this is less than
+  # max_idle_connections, then max_idle_connections will be reduced to match
+  # this value. If n <= 0, then there is no limit on the number of open
+  # connections. The default is 0 (unlimited).
+  max_open_connections: 4
+
+  # How long to wait for execution of a database query to complete.
+  # Defaults to 15s.
+  query_timeout: 15s
 
 # Move this to the relay config later.
 docker:

--- a/testing/config/no-database-password.yml
+++ b/testing/config/no-database-password.yml
@@ -1,7 +1,9 @@
 global:
-  # How long before a command times out, in seconds.
+  # How long before a command times out. Accepts a duration string: a sequence
+  # of decimal numbers, each with optional fraction and a unit suffix: 1d,
+  # 1h30m, 5m, 10s. Valid units are "ms", "s", "m", "h".
   # TODO Allow overriding at the command level
-  command_timeout_seconds: 60
+  command_timeout: 60s
 
 gort:
   # Gort will automatically create accounts for new users when set.
@@ -49,16 +51,33 @@ database:
   # Defaults to false.
   ssl_enabled: true
 
-  # Database connection pool size. Defaults to 10.
-  pool_size: 10
+  # The maximum amount of time a connection may be idle. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's idle time. Defaults to 1m.
+  connection_max_idle_time: 0s
 
-  # Number of milliseconds to wait to checkout a database connection from the pool.
-  # Defaults to 15000 ms.
-  pool_timeout: 15000
+  # The maximum amount of time a connection may be reused. Expired connections
+  # may be closed lazily before reuse. If <= 0, connections are not closed due
+  # to a connection's age. Defaults to 10m
+  connection_max_life_time: 0s
 
-  # Amount of time to wait for execution of a database query to complete.
-  # Defaults to 15000 ms.
-  query_timeout: 15000
+  # Sets the maximum number of connections in the idle connection pool. If
+  # max_open_connections is > 0 but < max_idle_connections, then this value
+  # will be reduced to match max_open_connections.
+  # If n <= 0, no idle connections are retained.
+  # Defaults to 2
+  max_idle_connections: 2
+
+  # The maximum number of open connections to the database. If
+  # max_idle_connections is > 0 and the new this is less than
+  # max_idle_connections, then max_idle_connections will be reduced to match
+  # this value. If n <= 0, then there is no limit on the number of open
+  # connections. The default is 0 (unlimited).
+  max_open_connections: 0
+
+  # How long to wait for execution of a database query to complete.
+  # Defaults to 15s.
+  query_timeout: 15s
 
 # Move this to the relay config later.
 docker:

--- a/testing/config/no-database.yml
+++ b/testing/config/no-database.yml
@@ -1,7 +1,9 @@
 global:
-  # How long before a command times out, in seconds.
+  # How long before a command times out. Accepts a duration string: a sequence
+  # of decimal numbers, each with optional fraction and a unit suffix: 1d,
+  # 1h30m, 5m, 10s. Valid units are "ms", "s", "m", "h".
   # TODO Allow overriding at the command level
-  command_timeout_seconds: 60
+  command_timeout: 60s
 
 gort:
   # Gort will automatically create accounts for new users when set.
@@ -28,12 +30,12 @@ gort:
 
   # If set along with tls_key_file, TLS will be used for API connections.
   # This parameter specifies the path to a certificate file.
-  # tls_cert_file: host.crt
+  tls_cert_file: host.crt
 
   # If set along with tls_cert_file, TLS will be used for API connections.
   # This parameter specifies the path to a key file.
   # The key must not be encrypted with a password.
-  # tls_key_file: host.key
+  tls_key_file: host.key
 
 # Move this to the relay config later.
 docker:

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -67,7 +67,7 @@ func NewWorker(image string, tag string, entryPoint string, commandParams ...str
 		DockerClient:      dcli,
 		DockerHost:        config.GetDockerConfigs().DockerHost,
 		EntryPoint:        entryPoint,
-		ExecutionTimeout:  config.GetGlobalConfigs().CommandTimeout(),
+		ExecutionTimeout:  config.GetGlobalConfigs().CommandTimeout,
 		ImageName:         image + ":" + tag,
 		ExitStatus:        make(chan int64),
 	}, nil


### PR DESCRIPTION
Updated configuration to use durations for time-based configurations.

So, for example, `command_timeout_seconds: 60` becomes `command_timeout: 60s`. This allows users to use duration strings to set arbitrary durations (`1d`, `1h30m`, `5m`, etc.)

Also found that the `database` configs were being ignored, so I also updated these to allow basic connection settings, and applied them accordingly.