### PR TITLE
Inject default envvars into each container as per docs

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -553,6 +553,9 @@ func adapterLogEntry(ctx context.Context, e *log.Entry, obs ...interface{}) *log
 			e = e.WithField("provider.user.email", o.Email).
 				WithField("provider.user.id", o.ID)
 
+		case *rest.User:
+			e = adapterLogEntry(ctx, e, *o)
+
 		case rest.User:
 			e = e.WithField("gort.user.name", o.Username)
 
@@ -666,6 +669,9 @@ func addSpanAttributes(ctx context.Context, sp trace.Span, obs ...interface{}) {
 				attribute.String("command.params", strings.Join(o.Parameters, " ")),
 				attribute.Int64("request.id", o.RequestID),
 			)
+
+		case *rest.User:
+			addSpanAttributes(ctx, sp, *o)
 
 		case rest.User:
 			attr = append(attr,

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -82,11 +82,18 @@ func SpawnWorker(ctx context.Context, command data.CommandRequest) (*worker.Work
 	_, sp := tr.Start(ctx, "relay.SpawnWorker")
 	defer sp.End()
 
-	image := command.Bundle.Docker.Image
-	tag := command.Bundle.Docker.Tag
-	entrypoint := command.Command.Executable
+	// Generate a token good for 10 seconds.
+	dal, err := dataaccess.Get()
+	if err != nil {
+		return nil, err
+	}
 
-	return worker.NewWorker(image, tag, entrypoint, command.Parameters...)
+	token, err := dal.TokenGenerate(ctx, command.UserName, 10*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	return worker.NewWorker(command, token)
 }
 
 // getUser is just a convenience function for interacting with the DAL.


### PR DESCRIPTION
Automatically injecting default envvars as per [the existing documentation](https://guide.getgort.io/command-environment-variables.html).

Specifically:

- `GORT_BUNDLE`: The name of the bundle the current command is a member of.
- `GORT_CHAT_HANDLE`: The chat handle of the user executing the command. This is the bare handle: a Slack user "@user" will result in a value of "user".
- `GORT_COMMAND`: The name of the current command being executed. Does not include the bundle; that is, when executing the command twitter:tweet, for example, GORT_COMMAND will equal "tweet".
- `GORT_INVOCATION_ID`: A unique ID string identifying the specific invocation within a pipeline stage .
- `GORT_ROOM`: The chat room where the command was invoked. This is the bare room name: if it was executed in the "#general" channel, this value would be "general". For direct messages, this will be the string "direct".
- `GORT_SERVICE_TOKEN`: A unique token for accessing Gort's service infrastructure.
- `GORT_SERVICES_ROOT`: Host and port for accessing Gort's service infrastructure.