### PR TITLE
Allow Gort CLI to be run as a command bundle

### DIFF
--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/getgort/gort/data/rest"
 	gerrs "github.com/getgort/gort/errors"
@@ -32,6 +33,17 @@ import (
 // If a valid token already exists it will be automatically invalidated if
 // this call is successful.
 func (c *GortClient) Authenticate() (rest.Token, error) {
+	// If the GORT_SERVICE_TOKEN envvar is set, use that first.
+	if te, exists := os.LookupEnv("GORT_SERVICE_TOKEN"); exists {
+		token := rest.Token{
+			Token:      te,
+			ValidFrom:  time.Now(),
+			ValidUntil: time.Now().Add(10 * time.Second),
+		}
+
+		return token, nil
+	}
+
 	endpointURL := fmt.Sprintf("%s/v2/authenticate", c.profile.URL)
 
 	postBytes, err := json.Marshal(c.profile.User())

--- a/data/config.go
+++ b/data/config.go
@@ -63,6 +63,7 @@ type DatabaseConfigs struct {
 // This will move into the relay config(s) eventually.
 type DockerConfigs struct {
 	DockerHost string `yaml:"host,omitempty"`
+	Network    string `yaml:"network,omitempty"`
 }
 
 // JaegerConfigs is the data wrapper for the "jaeger" section.

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -137,7 +137,14 @@ func (w *Worker) Start(ctx context.Context) (<-chan string, error) {
 	resp, err := func() (container.ContainerCreateCreatedBody, error) {
 		ctx, sp := tr.Start(ctx, "docker.ContainerCreate")
 		defer sp.End()
-		return cli.ContainerCreate(ctx, &cfg, nil, nil, nil, "")
+
+		// If a host network is defined, set it here.
+		var hc *container.HostConfig
+		if network := config.GetDockerConfigs().Network; network != "" {
+			hc = &container.HostConfig{NetworkMode: container.NetworkMode(network)}
+		}
+
+		return cli.ContainerCreate(ctx, &cfg, hc, nil, nil, "")
 	}()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This change makes the Gort CLI look for the `GORT_SERVICE_TOKEN` envvar that's passed to worker containers when they're started by the Gort controller [per this documentation](https://guide.getgort.io/command-environment-variables.html), and -- if it finds it -- to use that supplied token instead of authenticating with an existing password or token.

Changes:

- `client.Authenticate` and `client.Connect` both look for `GORT_SERVICE_TOKEN` and -- if present -- use the supplied token (which in practice is provided by the Gort controller and is valid for ten seconds).
- Added a `docker.network` value to the config. If set, any containers started by the worker use that network. This is handy when running the Gort controller in Docker, for example.

It seems to actually work, too!

```
$ !gort user list

GortAPP  7:57 PM
USERNAME  FULL NAME           EMAIL ADDRESS
admin     Gort Administrator  matthew.titmus@gmail.com
```