### PR TITLE
Create a 'hidden' subcommand for hidden CLI commands

### DIFF
--- a/cli/hidden-commands.go
+++ b/cli/hidden-commands.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/getgort/gort/client"
+	"github.com/spf13/cobra"
+)
+
+const (
+	hiddenCommandsUse   = "commands"
+	hiddenCommandsShort = "List all available commands"
+	hiddenCommandsLong  = "Lists all available commands."
+)
+
+// GetHiddenCommandsCmd is a command
+func GetHiddenCommandsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   hiddenCommandsUse,
+		Short: hiddenCommandsShort,
+		Long:  hiddenCommandsLong,
+		RunE:  hiddenCommandsCmd,
+	}
+
+	return cmd
+}
+
+func hiddenCommandsCmd(cmd *cobra.Command, args []string) error {
+	gortClient, err := client.Connect(FlagGortProfile)
+	if err != nil {
+		return err
+	}
+
+	bundles, err := gortClient.BundleList()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("I know about these commands:\n\n")
+
+	cmds := []string{}
+
+	for _, b := range bundles {
+		for k, _ := range b.Commands {
+			cmds = append(cmds, fmt.Sprintf("%s:%s", b.Name, k))
+		}
+	}
+
+	sort.Strings(cmds)
+
+	for _, c := range cmds {
+		fmt.Println(c)
+	}
+
+	return nil
+}

--- a/cli/hidden.go
+++ b/cli/hidden.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const (
+	hiddenUse   = "hidden"
+	hiddenShort = "Hidden commands, mostly for use via the Gort bundle."
+	hiddenLong  = "Hidden commands, mostly for use via the Gort bundle."
+)
+
+// GetHiddenCmd hidden
+func GetHiddenCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    hiddenUse,
+		Short:  hiddenShort,
+		Long:   hiddenLong,
+		Hidden: true,
+	}
+
+	cmd.AddCommand(GetHiddenCommandsCmd())
+
+	return cmd
+}

--- a/cmd-root.go
+++ b/cmd-root.go
@@ -41,6 +41,7 @@ func GetRootCmd() *cobra.Command {
 	root.AddCommand(cli.GetBootstrapCmd())
 	root.AddCommand(cli.GetBundleCmd())
 	root.AddCommand(cli.GetGroupCmd())
+	root.AddCommand(cli.GetHiddenCmd())
 	root.AddCommand(cli.GetRoleCmd())
 	root.AddCommand(cli.GetUserCmd())
 	root.AddCommand(cli.GetVersionCmd())


### PR DESCRIPTION
This creates a "hidden" command under which commands intended to be used only via the Gort bundle (but not harmful if they're discovered and used via the CLI).

The first such command is `hidden commands`, which is `!operable:help` command [demonstrated here](https://web.archive.org/web/20191203070840/http://book.cog.bot/sections/commands_and_bundles.html#).

Later revisions of `commands` will accept arguments and return information about specific commands.