### PR TITLE
Fix syntax in committed config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -137,7 +137,7 @@ bundles:
   commands:
     echo:
       description: "Echos back anything sent to it, all at once."
-      executable: "/bin/echo"
+      executable: [ "/bin/echo" ]
     splitecho:
       description: "Echos back anything sent to it, one parameter at a time."
       executable: [ "/opt/app/splitecho.sh" ]


### PR DESCRIPTION
Running `go run . start` from a fresh clone of the repo errored out due to a recent change to the executable field.