### PR TITLE
Create 'gort profile' commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,6 @@ coverage.html
 test.yml
 development.yml
 
+.vscode
+
 gort

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "gerrs",
         "seekrit"
     ],
     "cSpell.ignoreWords": [

--- a/cli/profile-create.go
+++ b/cli/profile-create.go
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/getgort/gort/client"
+	"github.com/spf13/cobra"
+)
+
+// $ cogctl profile create --help
+// Usage: cogctl profile create [OPTIONS] NAME URL USER PASSWORD
+//
+// Add a new profile to a the configuration file.
+//
+// Options:
+// --help  Show this message and exit.
+
+const (
+	profileCreateUse   = "create"
+	profileCreateShort = "Create a new Gort user profile"
+	profileCreateLong  = "Adds a new profile with the given name for the specified Gort server."
+	profileCreateUsage = `Usage:
+  gort profile create [flags] profile_name url user password
+
+Flags:
+  -h, --help   Show this message and exit
+`
+)
+
+// GetProfileCreateCmd is a command
+func GetProfileCreateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   profileCreateUse,
+		Short: profileCreateShort,
+		Long:  profileCreateLong,
+		RunE:  profileCreateCmd,
+		Args:  cobra.ExactArgs(4),
+	}
+
+	cmd.SetUsageTemplate(profileCreateUsage)
+
+	return cmd
+}
+
+func profileCreateCmd(cmd *cobra.Command, args []string) error {
+	profile, err := client.LoadClientProfile()
+	if err != nil {
+		fmt.Println("Failed to load existing profiles:", err)
+		return nil
+	}
+
+	if len(profile.Profiles) == 0 {
+		fmt.Println("No profile file found. Creating.")
+	}
+
+	name := args[0]
+	urlstring := args[1]
+	user := args[2]
+	password := args[3]
+
+	if _, exists := profile.Profiles[name]; exists {
+		fmt.Printf("Profile '%s' already exists.\n", name)
+		return nil
+	}
+
+	furl, err := url.Parse(urlstring)
+	if err != nil {
+		fmt.Printf("Failed to parse URL '%s': %s\n", urlstring, err.Error())
+		return nil
+	}
+
+	pe := client.ProfileEntry{
+		Name:      name,
+		URLString: furl.String(),
+		Password:  password,
+		Username:  user,
+	}
+
+	profile.Profiles[name] = pe
+
+	if profile.Defaults.Profile == "" {
+		profile.Defaults.Profile = pe.Name
+	}
+
+	err = client.SaveClientProfile(profile)
+	if err != nil {
+		fmt.Printf("Failed to update profile: %s\n", err.Error())
+		return nil
+	}
+
+	fmt.Printf("Profile '%s' (%s@%s) created.\n", pe.Name, pe.Username, pe.URLString)
+
+	return nil
+}

--- a/cli/profile-default.go
+++ b/cli/profile-default.go
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/getgort/gort/client"
+	"github.com/spf13/cobra"
+)
+
+// $ cogctl profile default --help
+// Usage: cogctl profile default [OPTIONS] NAME
+//
+// Sets the default profile in the configuration file.
+//
+// Options:
+// --help  Show this message and exit.
+
+const (
+	profileDefaultUse   = "default"
+	profileDefaultShort = "Sets the default Gort user profile"
+	profileDefaultLong  = "Sets the default Gort user profile."
+	profileDefaultUsage = `Usage:
+  gort profile default [flags] profile_name
+
+Flags:
+  -h, --help   Show this message and exit
+`
+)
+
+// GetProfileDefaultCmd is a command
+func GetProfileDefaultCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   profileDefaultUse,
+		Short: profileDefaultShort,
+		Long:  profileDefaultLong,
+		RunE:  profileDefaultCmd,
+		Args:  cobra.ExactArgs(1),
+	}
+
+	cmd.SetUsageTemplate(profileDefaultUsage)
+
+	return cmd
+}
+
+func profileDefaultCmd(cmd *cobra.Command, args []string) error {
+	profile, err := client.LoadClientProfile()
+	if err != nil {
+		fmt.Println("Failed to load existing profiles:", err)
+		return nil
+	}
+
+	if len(profile.Profiles) == 0 {
+		fmt.Println("No profile file found.")
+		fmt.Println("Use 'gort profile create' to create a new profile.")
+		return nil
+	}
+
+	name := args[0]
+
+	if _, exists := profile.Profiles[name]; !exists {
+		fmt.Printf("Profile '%s' doesn't exist.\n", name)
+		return nil
+	}
+
+	profile.Defaults.Profile = name
+
+	err = client.SaveClientProfile(profile)
+	if err != nil {
+		fmt.Printf("Failed to update profile: %s\n", err.Error())
+		return nil
+	}
+
+	fmt.Printf("Profile '%s' set to default.\n", name)
+
+	return nil
+}

--- a/cli/profile-delete.go
+++ b/cli/profile-delete.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/getgort/gort/client"
+	"github.com/spf13/cobra"
+)
+
+const (
+	profileDeleteUse   = "delete"
+	profileDeleteShort = "Delete an existing Gort user profile"
+	profileDeleteLong  = "Delete an existing Gort user profile."
+	profileDeleteUsage = `Usage:
+  gort profile delete [flags] profile_name
+
+Flags:
+  -h, --help   Show this message and exit
+`
+)
+
+// GetProfileDeleteCmd is a command
+func GetProfileDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   profileDeleteUse,
+		Short: profileDeleteShort,
+		Long:  profileDeleteLong,
+		RunE:  profileDeleteCmd,
+		Args:  cobra.ExactArgs(4),
+	}
+
+	cmd.SetUsageTemplate(profileDeleteUsage)
+
+	return cmd
+}
+
+func profileDeleteCmd(cmd *cobra.Command, args []string) error {
+	profile, err := client.LoadClientProfile()
+	if err != nil {
+		fmt.Println("Failed to load existing profiles:", err)
+		return nil
+	}
+
+	if len(profile.Profiles) == 0 {
+		fmt.Println("No profile file found.")
+		fmt.Println("Use 'gort profile create' to create a new profile.")
+		return nil
+	}
+
+	name := args[0]
+
+	if _, exists := profile.Profiles[name]; !exists {
+		fmt.Printf("Profile '%s' doesn't exist.\n", name)
+		return nil
+	}
+
+	delete(profile.Profiles, name)
+
+	if profile.Defaults.Profile == name {
+		fmt.Println("WARNING: Deleting default profile!")
+		profile.Defaults.Profile = ""
+	}
+
+	err = client.SaveClientProfile(profile)
+	if err != nil {
+		fmt.Printf("Failed to update profile: %s\n", err.Error())
+		return nil
+	}
+
+	fmt.Printf("Profile '%s' deleted.\n", name)
+
+	return nil
+}

--- a/cli/profile-list.go
+++ b/cli/profile-list.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/getgort/gort/client"
+	"github.com/spf13/cobra"
+)
+
+const (
+	profileListUse   = "list"
+	profileListShort = "List existing Gort user profiles"
+	profileListLong  = "List existing Gort user profiles."
+	profileListUsage = `Usage:
+  gort profile list
+
+Flags:
+  -h, --help   Show this message and exit
+`
+)
+
+// GetProfileListCmd is a command
+func GetProfileListCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   profileListUse,
+		Short: profileListShort,
+		Long:  profileListLong,
+		RunE:  profileListCmd,
+		Args:  cobra.ExactArgs(0),
+	}
+
+	cmd.SetUsageTemplate(profileListUsage)
+
+	return cmd
+}
+
+func profileListCmd(cmd *cobra.Command, args []string) error {
+	profile, err := client.LoadClientProfile()
+	if err != nil {
+		fmt.Println("Failed to load existing profiles:", err)
+		return nil
+	}
+
+	if len(profile.Profiles) == 0 {
+		fmt.Println("No profile file found.")
+		fmt.Println("Use 'gort profile create' to create a new profile.")
+		return nil
+	}
+
+	lens := map[string]int{}
+	names := []string{}
+
+	for name, p := range profile.Profiles {
+		names = append(names, name)
+
+		if len(name) > lens["name"] {
+			lens["name"] = len(name)
+		}
+
+		if len(p.Username) > lens["username"] {
+			lens["username"] = len(p.Username)
+		}
+
+		if len(p.URL.String()) > lens["url"] {
+			lens["url"] = len(p.URL.String())
+		}
+	}
+
+	sort.Strings(names)
+
+	f := fmt.Sprintf("%%-%ds %%-%ds %%-%ds %%s\n",
+		lens["name"]+3, lens["username"]+3, lens["url"]+3)
+
+	fmt.Printf(f, "Name", "User", "URL", "Default")
+
+	for name, p := range profile.Profiles {
+		def := ""
+		if name == profile.Defaults.Profile {
+			def = "   *"
+		}
+		fmt.Printf(f, name, p.Username, p.URL.String(), def)
+	}
+
+	return nil
+}

--- a/cli/profile.go
+++ b/cli/profile.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// $ cogctl profile --help
+// Usage: cogctl profile [OPTIONS] COMMAND [ARGS]...
+
+// Manage Cog profiles.
+
+// If invoked without a subcommand, lists all the profiles in the config
+// file.
+
+// Options:
+// --help  Show this message and exit.
+
+// Commands:
+// create   Add a new profile to a the configuration...
+// default  Sets the default profile in the configuration...
+
+const (
+	profileUse   = "profile"
+	profileShort = "Manage Gort profiles"
+	profileLong  = "Manage Gort profiles."
+)
+
+// GetProfileCmd profile
+func GetProfileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   profileUse,
+		Short: profileShort,
+		Long:  profileLong,
+	}
+
+	cmd.AddCommand(GetProfileCreateCmd())
+	cmd.AddCommand(GetProfileDefaultCmd())
+	cmd.AddCommand(GetProfileDeleteCmd())
+	cmd.AddCommand(GetProfileListCmd())
+
+	return cmd
+}

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -120,7 +120,7 @@ func (c *GortClient) Bootstrap(user rest.User) (rest.User, error) {
 	endpointURL := fmt.Sprintf("%s/v2/bootstrap", c.profile.URL)
 
 	// Get profile data so we can update it afterwards
-	profile, err := loadClientProfile()
+	profile, err := LoadClientProfile()
 	if err != nil {
 		return rest.User{}, err
 	}
@@ -170,7 +170,7 @@ func (c *GortClient) Bootstrap(user rest.User) (rest.User, error) {
 	}
 
 	profile.Profiles[entry.Name] = entry
-	err = saveClientProfile(profile)
+	err = SaveClientProfile(profile)
 	if err != nil {
 		return user, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -127,7 +127,7 @@ func Connect(profileName string) (*GortClient, error) {
 	var entry ProfileEntry
 
 	// Load the profiles file
-	profile, err := loadClientProfile()
+	profile, err := LoadClientProfile()
 	if err != nil {
 		return nil, gerrs.Wrap(ErrBadProfile, err)
 	}

--- a/client/profile.go
+++ b/client/profile.go
@@ -53,12 +53,12 @@ type ProfileDefaults struct {
 // ProfileEntry represents a single profile entry.
 type ProfileEntry struct {
 	Name          string   `yaml:"-"`
-	URLString     string   `yaml:"url"`
-	Password      string   `yaml:"password"`
+	URLString     string   `yaml:"url,omitempty"`
+	Password      string   `yaml:"password,omitempty"`
 	URL           *url.URL `yaml:"-"`
-	Username      string   `yaml:"user"`
-	AllowInsecure bool     `yaml:"allow_insecure"`
-	TLSCertFile   string   `yaml:"tls_cert_file"`
+	Username      string   `yaml:"user,omitempty"`
+	AllowInsecure bool     `yaml:"allow_insecure,omitempty"`
+	TLSCertFile   string   `yaml:"tls_cert_file,omitempty"`
 }
 
 // User is a convenience method that returns a rest.User pre-set with the
@@ -70,7 +70,7 @@ func (pe ProfileEntry) User() rest.User {
 // loadClientProfile loads and returns the complete client profile. If there's
 // no profile file, an empty Profile is returned. An error is returned if
 // there's an underlying IO error.
-func loadClientProfile() (Profile, error) {
+func LoadClientProfile() (Profile, error) {
 	profile := Profile{Profiles: make(map[string]ProfileEntry)}
 
 	configDir, err := getGortConfigDir()
@@ -118,7 +118,7 @@ func loadClientProfile() (Profile, error) {
 	return profile, err
 }
 
-func saveClientProfile(profile Profile) error {
+func SaveClientProfile(profile Profile) error {
 	configDir, err := getGortConfigDir()
 	if err != nil {
 		return err

--- a/cmd-root.go
+++ b/cmd-root.go
@@ -42,10 +42,11 @@ func GetRootCmd() *cobra.Command {
 	root.AddCommand(cli.GetBundleCmd())
 	root.AddCommand(cli.GetGroupCmd())
 	root.AddCommand(cli.GetHiddenCmd())
+	root.AddCommand(cli.GetPermissionCmd())
+	root.AddCommand(cli.GetProfileCmd())
 	root.AddCommand(cli.GetRoleCmd())
 	root.AddCommand(cli.GetUserCmd())
 	root.AddCommand(cli.GetVersionCmd())
-	root.AddCommand(cli.GetPermissionCmd())
 
 	root.PersistentFlags().StringVarP(&cli.FlagGortProfile, "profile", "P", "", "The Gort profile within the config file to use")
 


### PR DESCRIPTION
Adds the following subcommands:

* `gort profile list` -- Lists existing profiles
* `gort profile create` -- Adds a new profile
* `gort profile default` -- Sets the default profile
* `gort profile delete` -- Deletes an existing profile

Also, made the `client.loadClientProfile` and `client. loadClientProfile` functions exported.

Resolves https://github.com/getgort/gort/issues/71.