### PR TITLE
Implement `LongDescription` for bundle commands

### DIFF
--- a/bundles/bundle_test.go
+++ b/bundles/bundle_test.go
@@ -38,9 +38,15 @@ func TestLoadBundle(t *testing.T) {
 	assert.Equal(t, "ubuntu", b.Docker.Image)
 	assert.Equal(t, "20.04", b.Docker.Tag)
 	assert.Len(t, b.Commands, 1)
-	assert.Equal(t, "echox", b.Commands["echox"].Name)
-	assert.Equal(t, "Echos back anything sent to it, all at once.", b.Commands["echox"].Description)
-	assert.Equal(t, []string{"/bin/echo"}, b.Commands["echox"].Executable)
-	assert.Len(t, b.Commands["echox"].Rules, 1)
-	assert.Equal(t, "must have test:echox", b.Commands["echox"].Rules[0])
+
+	cmd := b.Commands["echox"]
+	assert.Equal(t, "echox", cmd.Name)
+	assert.Equal(t, "Write arguments to the standard output.", cmd.Description)
+	assert.Equal(t, `Write arguments to the standard output.
+
+Usage:
+  test:echox [string ...]`, cmd.LongDescription)
+	assert.Equal(t, []string{"/bin/echo"}, cmd.Executable)
+	assert.Len(t, cmd.Rules, 1)
+	assert.Equal(t, "must have test:echox", cmd.Rules[0])
 }

--- a/bundles/default.yml
+++ b/bundles/default.yml
@@ -135,6 +135,6 @@ commands:
 
       Usage:
         gort:help [flags] [command]
-    executable: [ "/bin/gort", "hidden", "commands" ]
+    executable: [ "/bin/gort", "hidden", "command" ]
     rules:
       - allow

--- a/cli/hidden-command.go
+++ b/cli/hidden-command.go
@@ -112,7 +112,8 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 				continue
 			}
 
-			fmt.Printf("Command: %s:%s\n", b.Name, k)
+			fmt.Printf("%s:%s\n------------------------------\n", b.Name, k)
+
 			if len(v.LongDescription) > 0 {
 				fmt.Println(v.LongDescription)
 			} else if len(v.Description) > 0 {

--- a/cli/hidden-command.go
+++ b/cli/hidden-command.go
@@ -45,11 +45,13 @@ Flags:
 // GetHiddenCommandCmd is a command
 func GetHiddenCommandCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   hiddenCommandUse,
-		Short: hiddenCommandShort,
-		Long:  hiddenCommandLong,
-		RunE:  hiddenCommandCmd,
-		Args:  cobra.RangeArgs(0, 1),
+		Use:           hiddenCommandUse,
+		Short:         hiddenCommandShort,
+		Long:          hiddenCommandLong,
+		RunE:          hiddenCommandCmd,
+		Args:          cobra.RangeArgs(0, 1),
+		SilenceErrors: true,
+		SilenceUsage:  true,
 	}
 
 	cmd.SetUsageTemplate(hiddenCommandUsage)

--- a/cli/hidden-command.go
+++ b/cli/hidden-command.go
@@ -94,8 +94,17 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 	var found bool
 
 	for _, b := range bundles {
+		if !b.Enabled {
+			continue
+		}
+
 		if bundleName != "" && bundleName != b.Name {
 			continue
+		}
+
+		// If multiple commands are found, insert a space between them.
+		if found {
+			fmt.Println()
 		}
 
 		for k, v := range b.Commands {
@@ -103,8 +112,7 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 				continue
 			}
 
-			fmt.Printf("%s:%s\n", b.Name, k)
-			fmt.Println("==")
+			fmt.Printf("Command: %s:%s\n", b.Name, k)
 			if len(v.LongDescription) > 0 {
 				fmt.Println(v.LongDescription)
 			} else if len(v.Description) > 0 {
@@ -117,7 +125,7 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 	}
 
 	if !found {
-		fmt.Printf("command not found: %v\n", command)
+		fmt.Printf("Command not found: %v\n", command)
 		return nil
 	}
 
@@ -135,6 +143,10 @@ func listAllCommands(gortClient *client.GortClient) error {
 	cmds := []string{}
 
 	for _, b := range bundles {
+		if !b.Enabled {
+			continue
+		}
+
 		for k := range b.Commands {
 			cmds = append(cmds, fmt.Sprintf("- %s:%s", b.Name, k))
 		}

--- a/data/bundle.go
+++ b/data/bundle.go
@@ -59,10 +59,11 @@ type BundleDocker struct {
 // BundleCommand represents a bundle command, as defined in the "bundles/commands"
 // section of the config.
 type BundleCommand struct {
-	Description string   `yaml:",omitempty" json:"description,omitempty"`
-	Executable  []string `yaml:",omitempty,flow" json:"executable,omitempty"`
-	Name        string   `yaml:"-" json:"-"`
-	Rules       []string `yaml:",omitempty" json:"rules,omitempty"`
+	Description     string   `yaml:",omitempty" json:"description,omitempty"`
+	Executable      []string `yaml:",omitempty,flow" json:"executable,omitempty"`
+	LongDescription string   `yaml:"long_description,omitempty" json:"long_description,omitempty"`
+	Name            string   `yaml:"-" json:"-"`
+	Rules           []string `yaml:",omitempty" json:"rules,omitempty"`
 }
 
 // CommandEntry conveniently wraps a bundle and one command within that bundle.

--- a/dataaccess/memory/bundle-access_test.go
+++ b/dataaccess/memory/bundle-access_test.go
@@ -41,8 +41,15 @@ func testBundleAccess(t *testing.T) {
 
 // Fail-fast: can the test bundle be loaded?
 func testLoadTestData(t *testing.T) {
-	_, err := getTestBundle()
+	b, err := getTestBundle()
 	assert.NoError(t, err)
+
+	assert.NotEmpty(t, b.Commands)
+	assert.NotEmpty(t, b.Commands["echox"].Description)
+	assert.NotEmpty(t, b.Commands["echox"].Executable)
+	assert.NotEmpty(t, b.Commands["echox"].LongDescription)
+	assert.NotEmpty(t, b.Commands["echox"].Name)
+	assert.NotEmpty(t, b.Commands["echox"].Rules)
 }
 
 func testBundleCreate(t *testing.T) {
@@ -407,6 +414,7 @@ func testFindCommandEntry(t *testing.T) {
 	tc := tb.Commands[CommandName]
 	cmd := ce[0].Command
 	assert.Equal(t, tc.Description, cmd.Description)
+	assert.Equal(t, tc.LongDescription, cmd.LongDescription)
 	assert.Equal(t, tc.Executable, cmd.Executable)
 	assert.Equal(t, tc.Name, cmd.Name)
 	assert.Equal(t, tc.Rules, cmd.Rules)

--- a/dataaccess/postgres/bundle-access_test.go
+++ b/dataaccess/postgres/bundle-access_test.go
@@ -41,8 +41,15 @@ func testBundleAccess(t *testing.T) {
 
 // Fail-fast: can the test bundle be loaded?
 func testLoadTestData(t *testing.T) {
-	_, err := getTestBundle()
+	b, err := getTestBundle()
 	assert.NoError(t, err)
+
+	assert.NotEmpty(t, b.Commands)
+	assert.NotEmpty(t, b.Commands["echox"].Description)
+	assert.NotEmpty(t, b.Commands["echox"].Executable)
+	assert.NotEmpty(t, b.Commands["echox"].LongDescription)
+	assert.NotEmpty(t, b.Commands["echox"].Name)
+	assert.NotEmpty(t, b.Commands["echox"].Rules)
 }
 
 func testBundleCreate(t *testing.T) {
@@ -407,6 +414,7 @@ func testFindCommandEntry(t *testing.T) {
 	tc := tb.Commands[CommandName]
 	cmd := ce[0].Command
 	assert.Equal(t, tc.Description, cmd.Description)
+	assert.Equal(t, tc.LongDescription, cmd.LongDescription)
 	assert.Equal(t, tc.Executable, cmd.Executable)
 	assert.Equal(t, tc.Name, cmd.Name)
 	assert.Equal(t, tc.Rules, cmd.Rules)

--- a/dataaccess/postgres/postgres-data-access.go
+++ b/dataaccess/postgres/postgres-data-access.go
@@ -285,6 +285,7 @@ func (da PostgresDataAccess) createBundlesTables(ctx context.Context, db *sql.DB
 		name				TEXT NOT NULL CHECK(name <> ''),
 		description			TEXT NOT NULL CHECK(description <> ''),
 		executable			TEXT NOT NULL,
+		long_description	TEXT,
 		CONSTRAINT			unq_bundle_command UNIQUE(bundle_name, bundle_version, name),
 		PRIMARY KEY			(bundle_name, bundle_version, name),
 		FOREIGN KEY 		(bundle_name, bundle_version) REFERENCES bundles(name, version)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       - postgres
     image: getgort/gort:latest
     command: "start -v"
+    environment:
+      - GORT_DB_PASSWORD=veryKleverPassw0rd!
     ports:
       - "4000:4000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       - postgres
     image: getgort/gort:latest
     command: "start -v"
-    environment:
-      - GORT_DB_PASSWORD=veryKleverPassw0rd!
     ports:
       - "4000:4000"
     volumes:

--- a/testing/test-bundle.yml
+++ b/testing/test-bundle.yml
@@ -19,7 +19,12 @@ docker:
 
 commands:
   echox:
-    description: "Echos back anything sent to it, all at once."
+    description: "Write arguments to the standard output."
+    long_description: |-
+      Write arguments to the standard output.
+
+      Usage:
+        test:echox [string ...]
     executable: [ "/bin/echo" ]
     rules:
       - must have test:echox


### PR DESCRIPTION
Added support for `long_description` field in bundle commands' YAML definitions.

1. Added a `LongDescription` field to the `data.BundleCommand` struct
1. Updated the `dataaccess.postgres.createBundlesTables` function to add a `long_description` to the `bundle_commands` table.
1. Updated the `dataaccess.postgres.doBundleCommandsDataGet` and `doBundleInsertCommands` functions accordingly.
1. Made `cli.detailCommand` function read the description from the command instead of the bundle (since it exists now). 
1. Updated existing tests appropriately.

This solves https://github.com/getgort/gort/issues/70.
