### PR TITLE
Remove email/password/name args from bootstrap

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -49,7 +49,7 @@ Flags:
 )
 
 var (
-	flagAllowInsecure bool
+	flagBootstrapAllowInsecure bool
 )
 
 // GetBootstrapCmd bootstrap
@@ -62,7 +62,7 @@ func GetBootstrapCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().BoolVarP(&flagAllowInsecure, "allow-insecure", "i", false, "Permit http URLs to be used")
+	cmd.Flags().BoolVarP(&flagBootstrapAllowInsecure, "allow-insecure", "i", false, "Permit http URLs to be used")
 
 	cmd.SetUsageTemplate(bootstrapUsage)
 
@@ -73,7 +73,7 @@ func bootstrapCmd(cmd *cobra.Command, args []string) error {
 	entry := client.ProfileEntry{
 		Name:          FlagGortProfile,
 		URLString:     args[0],
-		AllowInsecure: flagAllowInsecure,
+		AllowInsecure: flagBootstrapAllowInsecure,
 	}
 
 	gortClient, err := client.ConnectWithNewProfile(entry)

--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/getgort/gort/client"
-	"github.com/getgort/gort/data/rest"
 )
 
 const (
@@ -44,19 +43,13 @@ bootstrapped. This can be overridden using the -P or --profile flags.`
   gort bootstrap [flags] [URL]
 
 Flags:
-  -i, --allow-insecure    Permit http URLs to be used
-  -e, --email string      Email for the bootstrapped user (default "admin@gort")
-  -h, --help              Show this message and exit.
-  -n, --name string       Full name of the bootstrapped user (default "Gort Administrator")
-  -p, --password string   Password for bootstrapped user (default generated)
+  -i, --allow-insecure   Permit http URLs to be used
+  -h, --help             help for bootstrap
 `
 )
 
 var (
-	flagBootstrapEmail    string
-	flagBootstrapName     string
-	flagBootstrapPassword string
-	flagAllowInsecure     bool
+	flagAllowInsecure bool
 )
 
 // GetBootstrapCmd bootstrap
@@ -69,9 +62,6 @@ func GetBootstrapCmd() *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 	}
 
-	cmd.Flags().StringVarP(&flagBootstrapEmail, "email", "e", "admin@gort", "Email for the bootstrapped user")
-	cmd.Flags().StringVarP(&flagBootstrapName, "name", "n", "Gort Administrator", "Full name of the bootstrapped user")
-	cmd.Flags().StringVarP(&flagBootstrapPassword, "password", "p", "", "Password for bootstrapped user (default generated)")
 	cmd.Flags().BoolVarP(&flagAllowInsecure, "allow-insecure", "i", false, "Permit http URLs to be used")
 
 	cmd.SetUsageTemplate(bootstrapUsage)
@@ -91,15 +81,9 @@ func bootstrapCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	user := rest.User{
-		Email:    flagBootstrapEmail,
-		FullName: flagBootstrapName,
-		Password: flagBootstrapPassword,
-	}
-
 	// Client Bootstrap will create the gort config if necessary, and append
 	// the new credentials to it.
-	user, err = gortClient.Bootstrap(user)
+	user, err := gortClient.Bootstrap()
 	if err != nil {
 		return err
 	}

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -116,7 +116,7 @@ func (c *GortClient) Authenticated() (bool, error) {
 }
 
 // Bootstrap calls the POST /v2/bootstrap endpoint.
-func (c *GortClient) Bootstrap(user rest.User) (rest.User, error) {
+func (c *GortClient) Bootstrap() (rest.User, error) {
 	endpointURL := fmt.Sprintf("%s/v2/bootstrap", c.profile.URL)
 
 	// Get profile data so we can update it afterwards
@@ -125,7 +125,7 @@ func (c *GortClient) Bootstrap(user rest.User) (rest.User, error) {
 		return rest.User{}, err
 	}
 
-	postBytes, err := json.Marshal(user)
+	postBytes, err := json.Marshal(rest.User{})
 	if err != nil {
 		return rest.User{}, gerrs.Wrap(gerrs.ErrMarshal, err)
 	}
@@ -154,7 +154,7 @@ func (c *GortClient) Bootstrap(user rest.User) (rest.User, error) {
 		return rest.User{}, gerrs.Wrap(gerrs.ErrIO, err)
 	}
 
-	// Re-using "user" instance. Sorry.
+	user := rest.User{}
 	err = json.Unmarshal(body, &user)
 	if err != nil {
 		return rest.User{}, gerrs.Wrap(gerrs.ErrUnmarshal, err)


### PR DESCRIPTION
Removes email, username, and password args form the `bootstrap` command.

We should encourage users to create their own non-admin users, and not create an admin user for them to use day-to-day.