### PR TITLE
Add Columnizer utility for formatting CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ Gort brings the power of the command line to the place you collaborate with your
 
 The official documentation can be found here: [The Gort Guide](http://guide.getgort.io/).
 
+## History
+
+Gort was initially conceived of as a Go re-implementation of Operable's [Cog Slack Bot](https://github.com/operable/cog), and while it remains heavily inspired by Cog, Gort has largely gone its own way.
+
+During our initial design process, we found that many of Cog’s features, however innovative, went largely unused, and the codebase had become difficult to extend and maintain, and its implementation language -- Elixir -- which has relatively few proficient developers. The solution, which was discussed for many months on the Cog Slack workspace, was to rewrite Cog from scratch in such as Go, removing some of less-used functionality and reducing complexity in the process.
+
+This gave us the opportunity to consider and possibly redefine what Cog was meant to be. To choose the features that make sense, and to discard those that don't. In this way, Gort can be described more as a “spiritual successor” to Cog than a faithful re-implementation.
+
 ## Features
 
 Gort's design philosophy emphasizes flexibility and security by allowing you to build commands in any language you want, using tooling you're already comfortable with, and can tightly control who can use them and how.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The official documentation can be found here: [The Gort Guide](http://guide.getg
 
 Gort was initially conceived of as a Go re-implementation of Operable's [Cog Slack Bot](https://github.com/operable/cog), and while it remains heavily inspired by Cog, Gort has largely gone its own way.
 
-During our initial design process, we found that many of Cog’s features, however innovative, went largely unused, and the codebase had become difficult to extend and maintain, and its implementation language -- Elixir -- which has relatively few proficient developers. The solution, which was discussed for many months on the Cog Slack workspace, was to rewrite Cog from scratch in such as Go, removing some of less-used functionality and reducing complexity in the process.
+During our initial design process, we found that many of Cog’s features, however innovative, went largely unused, and the codebase had become difficult to extend and maintain. Additionally, its implementation language -- Elixir -- had relatively few proficient developers. The solution, which was discussed for many months on the Cog Slack workspace, was to rewrite Cog from scratch in such as Go, removing some of less-used functionality and reducing complexity in the process.
 
 This gave us the opportunity to consider and possibly redefine what Cog was meant to be. To choose the features that make sense, and to discard those that don't. In this way, Gort can be described more as a “spiritual successor” to Cog than a faithful re-implementation.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ What's more, because your executable receives all chat inputs exactly as if it w
 
 More information about writing commands can be found in the Gort Guide:
 
-* [Gort Guide: Writing a Command Bundle](writing-a-command-bundle.md)
+* [Gort Guide: Writing a Command Bundle](https://guide.getgort.io/writing-a-command-bundle.html)
 
 ### Commands are packaged into bundles that can be installed in Gort
 

--- a/cli/columnizer.go
+++ b/cli/columnizer.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type IntFunc func(i int) int
+
+type StringFunc func(i int) string
+
+type Columnizer struct {
+	columns []column
+}
+
+type column struct {
+	name string
+	f    interface{}
+}
+
+func (c *Columnizer) IntColumn(name string, f IntFunc) *Columnizer {
+	c.columns = append(c.columns, column{name: name, f: f})
+	return c
+}
+
+func (c *Columnizer) StringColumn(name string, f StringFunc) *Columnizer {
+	c.columns = append(c.columns, column{name: name, f: f})
+	return c
+}
+
+// Will panic if o isn't a slice.
+func (c *Columnizer) Format(o interface{}) []string {
+	// Build meta-format string
+	headers := strings.Builder{}
+	meta := strings.Builder{}
+
+	columnWidths := make([]interface{}, len(c.columns))
+	columnNames := make([]interface{}, len(c.columns))
+
+	rv := reflect.ValueOf(o)
+	length := rv.Len()
+
+	// Loop over each column
+	for i, col := range c.columns {
+		columnNames[i] = col.name
+		columnWidths[i] = len(col.name)
+
+		headers.WriteString("%%-%ds")
+
+		switch f := col.f.(type) {
+		case IntFunc:
+			meta.WriteString("%%-%dd")
+			for j := 0; j < length; j++ {
+				w := len(fmt.Sprintf("%d", f(j)))
+				if w > columnWidths[i].(int) {
+					columnWidths[i] = w
+				}
+			}
+
+		case StringFunc:
+			meta.WriteString("%%-%ds")
+			for j := 0; j < length; j++ {
+				w := len(f(j))
+				if w > columnWidths[i].(int) {
+					columnWidths[i] = w
+				}
+			}
+
+		default:
+			panic(fmt.Sprintf("unknown type: %T", f))
+		}
+	}
+
+	for i := range columnWidths {
+		w := columnWidths[i].(int)
+		columnWidths[i] = w + 3
+	}
+
+	headerFormat := fmt.Sprintf(headers.String(), columnWidths...)
+	metaFormat := fmt.Sprintf(meta.String(), columnWidths...)
+
+	fmt.Println(headerFormat)
+	fmt.Println(metaFormat)
+
+	lines := []string{}
+	lines = append(lines, fmt.Sprintf(headerFormat, columnNames...))
+
+	for row := 0; row < length; row++ {
+		values := make([]interface{}, len(c.columns))
+
+		for i, col := range c.columns {
+			switch f := col.f.(type) {
+			case IntFunc:
+				values[i] = f(row)
+
+			case StringFunc:
+				values[i] = f(row)
+
+			default:
+				panic(fmt.Sprintf("unknown type: %T", f))
+			}
+		}
+
+		lines = append(lines, fmt.Sprintf(metaFormat, values...))
+	}
+
+	return lines
+}

--- a/cli/columnizer.go
+++ b/cli/columnizer.go
@@ -120,3 +120,10 @@ func (c *Columnizer) Format(o interface{}) []string {
 
 	return lines
 }
+
+// Print is a convenience function that prints the table to stdout.
+func (c *Columnizer) Print(o interface{}) {
+	for _, line := range c.Format(o) {
+		fmt.Println(line)
+	}
+}

--- a/cli/columnizer.go
+++ b/cli/columnizer.go
@@ -96,9 +96,6 @@ func (c *Columnizer) Format(o interface{}) []string {
 	headerFormat := fmt.Sprintf(headers.String(), columnWidths...)
 	metaFormat := fmt.Sprintf(meta.String(), columnWidths...)
 
-	fmt.Println(headerFormat)
-	fmt.Println(metaFormat)
-
 	lines := []string{}
 	lines = append(lines, fmt.Sprintf(headerFormat, columnNames...))
 

--- a/cli/user-list.go
+++ b/cli/user-list.go
@@ -17,7 +17,6 @@
 package cli
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/getgort/gort/client"
@@ -72,10 +71,7 @@ func userListCmd(cmd *cobra.Command, args []string) error {
 	c.StringColumn("USERNAME", func(i int) string { return users[i].Username })
 	c.StringColumn("FULL NAME", func(i int) string { return users[i].FullName })
 	c.StringColumn("EMAIL ADDRESS", func(i int) string { return users[i].Email })
-
-	for _, line := range c.Format(users) {
-		fmt.Println(line)
-	}
+	c.Print(users)
 
 	return nil
 }

--- a/cli/user-list.go
+++ b/cli/user-list.go
@@ -68,26 +68,13 @@ func userListCmd(cmd *cobra.Command, args []string) error {
 	// Sort by username, for presentation purposes.
 	sort.Slice(users, func(i, j int) bool { return users[i].Username < users[j].Username })
 
-	// We want a dynamic format that looks something like: %-10s%-10s%s
-	const metaFormat = "%%-%ds%%-%ds%%s\n"
+	c := &Columnizer{}
+	c.StringColumn("USERNAME", func(i int) string { return users[i].Username })
+	c.StringColumn("FULL NAME", func(i int) string { return users[i].FullName })
+	c.StringColumn("EMAIL ADDRESS", func(i int) string { return users[i].Email })
 
-	lenUsername, lenFullName := len("USERNAME"), len("FULL NAME")
-
-	for _, u := range users {
-		if len(u.Username) > lenUsername {
-			lenUsername = len(u.Username)
-		}
-
-		if len(u.FullName) > lenFullName {
-			lenFullName = len(u.FullName)
-		}
-	}
-
-	format := fmt.Sprintf(metaFormat, lenUsername+3, lenFullName+3)
-
-	fmt.Printf(format, "USERNAME", "FULL NAME", "EMAIL ADDRESS")
-	for _, u := range users {
-		fmt.Printf(format, u.Username, u.FullName, u.Email)
+	for _, line := range c.Format(users) {
+		fmt.Println(line)
 	}
 
 	return nil


### PR DESCRIPTION
Added the Columnizer utility to standardize CLI list/table output. It's super rough at the moment.

It allows you to build "columns" backed by a slice, which may be (at the moment) strings or integers.

Using it looks like the following (taken from an example usage has been added to `user-list.go`):

```go
c := &Columnizer{}
c.StringColumn("USERNAME", func(i int) string { return users[i].Username })
c.StringColumn("FULL NAME", func(i int) string { return users[i].FullName })
c.StringColumn("EMAIL ADDRESS", func(i int) string { return users[i].Email })
c.Print(users)
```