### PR TITLE
Can no longer bootstrap over an existing profile

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -45,6 +45,9 @@ bootstrapped. This can be overridden using the -P or --profile flags.`
 Flags:
   -i, --allow-insecure   Permit http URLs to be used
   -h, --help             help for bootstrap
+
+Global Flags:
+  -P, --profile string   The Gort profile within the config file to use
 `
 )
 

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -125,6 +125,10 @@ func (c *GortClient) Bootstrap() (rest.User, error) {
 		return rest.User{}, err
 	}
 
+	if _, exists := profile.Profiles[c.profile.Name]; exists {
+		return rest.User{}, fmt.Errorf("profile %s already exists", c.profile.Name)
+	}
+
 	postBytes, err := json.Marshal(rest.User{})
 	if err != nil {
 		return rest.User{}, gerrs.Wrap(gerrs.ErrMarshal, err)

--- a/client/client.go
+++ b/client/client.go
@@ -163,7 +163,7 @@ func ConnectWithNewProfile(entry ProfileEntry) (*GortClient, error) {
 	entry.URLString = url.String()
 
 	if entry.Name == "" {
-		entry.Name = url.Hostname()
+		entry.Name = fmt.Sprintf("%s_%s", url.Hostname(), url.Port())
 	}
 
 	return NewClient(entry)


### PR DESCRIPTION
Fixes https://github.com/getgort/gort/issues/74

Prevents a user blowing up an existing Gort profile entry by using `gort bootstrap`.