### PR TITLE
Update various `list` subcommands to consistently use the Columnizer

### DIFF
--- a/cli/bundle-list.go
+++ b/cli/bundle-list.go
@@ -17,8 +17,6 @@
 package cli
 
 import (
-	"fmt"
-
 	"github.com/getgort/gort/client"
 	"github.com/spf13/cobra"
 )
@@ -67,8 +65,6 @@ func GetBundleListCmd() *cobra.Command {
 }
 
 func bundleListCmd(cmd *cobra.Command, args []string) error {
-	const format = "%-12s%-12s%-12s%s\n"
-
 	gortClient, err := client.Connect(FlagGortProfile)
 	if err != nil {
 		return err
@@ -79,25 +75,24 @@ func bundleListCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf(format, "BUNDLE", "VERSION", "TYPE", "STATUS")
-
-	for _, b := range bundles {
-		if b.Version == "" {
-			b.Version = "-"
-		}
-
-		status := "Disabled"
-		if b.Enabled {
-			status = "Enabled"
-		}
-
+	c := &Columnizer{}
+	c.StringColumn("BUNDLE", func(i int) string { return bundles[i].Name })
+	c.StringColumn("VERSION", func(i int) string { return bundles[i].Version })
+	c.StringColumn("TYPE", func(i int) string {
 		kind := "Explicit"
-		if b.Default {
+		if bundles[i].Default {
 			kind = "Default"
 		}
-
-		fmt.Printf(format, b.Name, b.Version, kind, status)
-	}
+		return kind
+	})
+	c.StringColumn("STATUS", func(i int) string {
+		status := "Disabled"
+		if bundles[i].Enabled {
+			status = "Enabled"
+		}
+		return status
+	})
+	c.Print(bundles)
 
 	return nil
 }

--- a/cli/group-list.go
+++ b/cli/group-list.go
@@ -17,7 +17,7 @@
 package cli
 
 import (
-	"fmt"
+	"sort"
 
 	"github.com/getgort/gort/client"
 	"github.com/spf13/cobra"
@@ -73,8 +73,6 @@ func GetGroupListCmd() *cobra.Command {
 }
 
 func groupListCmd(cmd *cobra.Command, args []string) error {
-	const format = "%s\n"
-
 	gortClient, err := client.Connect(FlagGortProfile)
 	if err != nil {
 		return err
@@ -85,10 +83,12 @@ func groupListCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf(format, "GROUP NAME")
-	for _, g := range groups {
-		fmt.Printf(format, g.Name)
-	}
+	// Sort by name, for presentation purposes.
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Name < groups[j].Name })
+
+	c := &Columnizer{}
+	c.StringColumn("GROUP NAME", func(i int) string { return groups[i].Name })
+	c.Print(groups)
 
 	return nil
 }

--- a/cli/permission-list.go
+++ b/cli/permission-list.go
@@ -54,8 +54,6 @@ func GetPermissionListCmd() *cobra.Command {
 }
 
 func permissionListCmd(cmd *cobra.Command, args []string) error {
-	const format = "%-12s\n"
-
 	gortClient, err := client.Connect(FlagGortProfile)
 	if err != nil {
 		return err

--- a/cli/permission-list.go
+++ b/cli/permission-list.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/getgort/gort/client"
 	"github.com/spf13/cobra"
@@ -65,13 +66,20 @@ func permissionListCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf(format, "NAME")
+	names := make([]string, 0)
 
 	for _, b := range bundles {
 		for _, p := range b.Permissions {
-			fmt.Printf(format, fmt.Sprintf("%v:%v", b.Name, p))
+			names = append(names, fmt.Sprintf("%v:%v", b.Name, p))
 		}
 	}
+
+	// Sort by name, for presentation purposes.
+	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+
+	c := &Columnizer{}
+	c.StringColumn("NAME", func(i int) string { return names[i] })
+	c.Print(names)
 
 	return nil
 }

--- a/cli/role-list.go
+++ b/cli/role-list.go
@@ -17,7 +17,7 @@
 package cli
 
 import (
-	"fmt"
+	"sort"
 
 	"github.com/getgort/gort/client"
 	"github.com/spf13/cobra"
@@ -53,8 +53,6 @@ func GetRoleListCmd() *cobra.Command {
 }
 
 func roleListCmd(cmd *cobra.Command, args []string) error {
-	const format = "%s\n"
-
 	gortClient, err := client.Connect(FlagGortProfile)
 	if err != nil {
 		return err
@@ -65,10 +63,12 @@ func roleListCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf(format, "ROLE NAME")
-	for _, g := range roles {
-		fmt.Printf(format, g.Name)
-	}
+	// Sort by name, for presentation purposes.
+	sort.Slice(roles, func(i, j int) bool { return roles[i].Name < roles[j].Name })
+
+	c := &Columnizer{}
+	c.StringColumn("ROLE NAME", func(i int) string { return roles[i].Name })
+	c.Print(roles)
 
 	return nil
 }

--- a/cli/user-list.go
+++ b/cli/user-list.go
@@ -64,13 +64,13 @@ func userListCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Sort by username, for presentation purposes.
+	// Sort by name, for presentation purposes.
 	sort.Slice(users, func(i, j int) bool { return users[i].Username < users[j].Username })
 
 	c := &Columnizer{}
-	c.StringColumn("USERNAME", func(i int) string { return users[i].Username })
+	c.StringColumn("USER NAME", func(i int) string { return users[i].Username })
 	c.StringColumn("FULL NAME", func(i int) string { return users[i].FullName })
-	c.StringColumn("EMAIL ADDRESS", func(i int) string { return users[i].Email })
+	c.StringColumn("EMAIL", func(i int) string { return users[i].Email })
 	c.Print(users)
 
 	return nil


### PR DESCRIPTION
The following commands now use the `Columnizer` for simple presentation. 

* `bundle-list.go`
* `group-list.go`
* `permission-list.go`
* `profile-list.go`
* `role-list.go`
* `user-list.go` (already used Columnizer)

For some commands this was a trivial change, and really only serves to be consistent.

Others, like `profile-list` and `bundle-list`, get quite a bit simpler.

Also, all list commands now sort by name.