### PR TITLE
Fix failures in tests when using `--count`

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,6 +111,13 @@ func TestIsUndefinedTrue2(t *testing.T) {
 }
 
 func TestStandardizeDatabaseConfigNone(t *testing.T) {
+	// Clear the password environment variable for repeated runs
+	err := os.Setenv(EnvDatabasePassword, "")
+	if err != nil {
+		t.Error(err.Error())
+		t.FailNow()
+	}
+
 	config, err := load("../testing/config/no-database-password.yml")
 	if err != nil {
 		t.Error(err.Error())

--- a/dataaccess/memory/base_test.go
+++ b/dataaccess/memory/base_test.go
@@ -31,6 +31,9 @@ var (
 )
 
 func testInitialize(t *testing.T) {
+	// Reset for repeated runs
+	Reset()
+
 	ctx, cancel = context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 

--- a/dataaccess/memory/memory-data-access.go
+++ b/dataaccess/memory/memory-data-access.go
@@ -48,3 +48,10 @@ func NewInMemoryDataAccess() *InMemoryDataAccess {
 func (da *InMemoryDataAccess) Initialize(ctx context.Context) error {
 	return nil
 }
+
+func Reset() {
+	dataAccess.bundles = make(map[string]*data.Bundle)
+	dataAccess.groups = make(map[string]*rest.Group)
+	dataAccess.users = make(map[string]*rest.User)
+	dataAccess.roles = make(map[string]*rest.Role)
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -30,11 +30,10 @@ import (
 
 	"github.com/getgort/gort/data/rest"
 	"github.com/getgort/gort/dataaccess"
+	"github.com/getgort/gort/dataaccess/memory"
 )
 
 var adminToken rest.Token
-
-var router *mux.Router
 
 // ResponseTester allows a single HTTP test to be sent to a router and the
 // result to be verified.
@@ -114,18 +113,17 @@ func (r ResponseTester) Test(t *testing.T, router *mux.Router) {
 }
 
 func createTestRouter() *mux.Router {
-	if router != nil {
-		return router
-	}
-
 	ctx := context.Background()
 
-	userAdmin, err := doBootstrap(ctx, rest.User{})
+	// Clear in-memory data for re-running tests
+	memory.Reset()
+
+	dataAccessLayer, err := dataaccess.Get()
 	if err != nil {
 		panic(err)
 	}
 
-	dataAccessLayer, err := dataaccess.Get()
+	userAdmin, err := doBootstrap(ctx, rest.User{})
 	if err != nil {
 		panic(err)
 	}
@@ -135,7 +133,7 @@ func createTestRouter() *mux.Router {
 		panic(err)
 	}
 
-	router = mux.NewRouter()
+	router := mux.NewRouter()
 	addAllMethodsToRouter(router)
 
 	return router


### PR DESCRIPTION
Ensure state is reset at the beginning of each test run so repeated tests can run in a single call to `go test`.

Fixes #102