### PR TITLE
Add missing flags to gort bundle list command

### DIFF
--- a/testing/test-bundle.yml
+++ b/testing/test-bundle.yml
@@ -2,7 +2,7 @@
 gort_bundle_version: 1
 
 name: test
-version: 0.0.1
+version: 0.0.2
 author: Matt Titmus <matthew.titmus@gmail.com>
 homepage: https://guide.getgort.io
 description: A test bundle.

--- a/testing/test-bundle.yml
+++ b/testing/test-bundle.yml
@@ -2,7 +2,7 @@
 gort_bundle_version: 1
 
 name: test
-version: 0.0.2
+version: 0.0.1
 author: Matt Titmus <matthew.titmus@gmail.com>
 homepage: https://guide.getgort.io
 description: A test bundle.


### PR DESCRIPTION
Resolves Issue #49.

Added following flags:
```
  -d, --disabled   List only disabled bundles
  -e, --enabled    List only enabled bundles
  -v, --verbose    Display additional bundle details
```

