### PR TITLE
Allow `group` subcommands to have multiple args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 # Part 1: Create a layer for Go module dependencies
 #
-FROM golang:1.16 as gomodules
+FROM golang:1.17 as gomodules
 
 WORKDIR /gort
 COPY go.mod go.sum /gort/

--- a/cli/group-add.go
+++ b/cli/group-add.go
@@ -73,12 +73,13 @@ func groupAddCmd(cmd *cobra.Command, args []string) error {
 	var errs int
 
 	for _, name := range usernames {
-		output := fmt.Sprintf("User added to %s: %s", groupname, name)
+		var output string
 
-		err = gortClient.GroupMemberAdd(groupname, name)
-		if err != nil {
+		if err := gortClient.GroupMemberAdd(groupname, name); err != nil {
 			output = fmt.Sprintf("User NOT added to %s: %s (%s)", groupname, name, err.Error())
 			errs++
+		} else {
+			output = fmt.Sprintf("User added to %s: %s", groupname, name)
 		}
 
 		fmt.Println(output)

--- a/cli/group-grant.go
+++ b/cli/group-grant.go
@@ -37,7 +37,7 @@ const (
 	groupGrantShort = "Grant a role to an existing group"
 	groupGrantLong  = "Grant a role to an existing group."
 	groupGrantUsage = `Usage:
-  gort group grant [flags] group_name role_name
+  gort group grant [flags] group_name role_name...
 
 Flags:
   -h, --help   Show this message and exit
@@ -54,7 +54,7 @@ func GetGroupGrantCmd() *cobra.Command {
 		Short: groupGrantShort,
 		Long:  groupGrantLong,
 		RunE:  groupGrantCmd,
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.MinimumNArgs(2),
 	}
 
 	cmd.SetUsageTemplate(groupGrantUsage)
@@ -64,19 +64,28 @@ func GetGroupGrantCmd() *cobra.Command {
 
 func groupGrantCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
-	rolename := args[1]
+	rolenames := args[1:]
 
 	gortClient, err := client.Connect(FlagGortProfile)
 	if err != nil {
 		return err
 	}
 
-	err = gortClient.GroupRoleAdd(groupname, rolename)
-	if err != nil {
-		return err
+	var errs int
+
+	for _, name := range rolenames {
+		output := fmt.Sprintf("Role added to %s: %s", groupname, name)
+
+		err = gortClient.GroupRoleAdd(groupname, name)
+		if err != nil {
+			output = fmt.Sprintf("Role NOT added to %s: %s (%s)", groupname, name, err.Error())
+			errs++
+		}
+
+		fmt.Println(output)
 	}
 
-	fmt.Printf("role added to %s: %s\n", groupname, rolename)
+	fmt.Printf("%d role(s) added; %d not added.\n", len(rolenames)-errs, errs)
 
 	return nil
 }

--- a/cli/group-grant.go
+++ b/cli/group-grant.go
@@ -74,12 +74,13 @@ func groupGrantCmd(cmd *cobra.Command, args []string) error {
 	var errs int
 
 	for _, name := range rolenames {
-		output := fmt.Sprintf("Role added to %s: %s", groupname, name)
+		var output string
 
-		err = gortClient.GroupRoleAdd(groupname, name)
-		if err != nil {
+		if err := gortClient.GroupRoleAdd(groupname, name); err != nil {
 			output = fmt.Sprintf("Role NOT added to %s: %s (%s)", groupname, name, err.Error())
 			errs++
+		} else {
+			output = fmt.Sprintf("Role added to %s: %s", groupname, name)
 		}
 
 		fmt.Println(output)

--- a/cli/group-remove.go
+++ b/cli/group-remove.go
@@ -74,12 +74,13 @@ func groupRemoveCmd(cmd *cobra.Command, args []string) error {
 	var errs int
 
 	for _, name := range usernames {
-		output := fmt.Sprintf("User removed from %s: %s", groupname, name)
+		var output string
 
-		err = gortClient.GroupMemberDelete(groupname, name)
-		if err != nil {
+		if err := gortClient.GroupMemberDelete(groupname, name); err != nil {
 			output = fmt.Sprintf("User NOT removed from %s: %s (%s)", groupname, name, err.Error())
 			errs++
+		} else {
+			output = fmt.Sprintf("User removed from %s: %s", groupname, name)
 		}
 
 		fmt.Println(output)

--- a/cli/group-revoke.go
+++ b/cli/group-revoke.go
@@ -66,12 +66,13 @@ func groupRevokeCmd(cmd *cobra.Command, args []string) error {
 	var errs int
 
 	for _, name := range rolenames {
-		output := fmt.Sprintf("Role removed from %s: %s", groupname, name)
+		var output string
 
-		err = gortClient.GroupRoleDelete(groupname, name)
-		if err != nil {
+		if err := gortClient.GroupRoleDelete(groupname, name); err != nil {
 			output = fmt.Sprintf("Role NOT removed from %s: %s (%s)", groupname, name, err.Error())
 			errs++
+		} else {
+			output = fmt.Sprintf("Role removed from %s: %s", groupname, name)
 		}
 
 		fmt.Println(output)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -225,7 +225,7 @@ func runWorker(ctx context.Context, worker *worker.Worker, response data.Command
 			response.Title = "Command Error"
 
 			if len(response.Output) == 0 {
-				response.Output = []string{"Unknown command error"}
+				response.Output = []string{"Unknown error executing command"}
 			}
 		}
 


### PR DESCRIPTION
Resolves the following issues:

* https://github.com/getgort/gort/issues/51
* https://github.com/getgort/gort/issues/52
* https://github.com/getgort/gort/issues/53
* https://github.com/getgort/gort/issues/54