### PR TITLE
Theothertomelliott/issue127

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,0 +1,2 @@
+docker_compose('docker-compose.yml')
+docker_build('getgort/gort', '.')


### PR DESCRIPTION
Fixes #127

Add a Tiltfile to run the docker-compose.yml and build the Gort container as needed.

To start: `tilt up`
To stop: `tilt down`