### PR TITLE
Add a bootstrap -F flag for when a profile already exists

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -43,8 +43,9 @@ bootstrapped. This can be overridden using the -P or --profile flags.`
   gort bootstrap [flags] [URL]
 
 Flags:
-  -i, --allow-insecure   Permit http URLs to be used
-  -h, --help             help for bootstrap
+  -i, --allow-insecure    Permit http URLs to be used
+  -F, --force-overwrite   Overwrite the profile if it already exists
+  -h, --help              help for bootstrap
 
 Global Flags:
   -P, --profile string   The Gort profile within the config file to use
@@ -52,7 +53,8 @@ Global Flags:
 )
 
 var (
-	flagBootstrapAllowInsecure bool
+	flagBootstrapAllowInsecure    bool
+	flagBootstrapOverwriteProfile bool
 )
 
 // GetBootstrapCmd bootstrap
@@ -66,6 +68,7 @@ func GetBootstrapCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&flagBootstrapAllowInsecure, "allow-insecure", "i", false, "Permit http URLs to be used")
+	cmd.Flags().BoolVarP(&flagBootstrapOverwriteProfile, "force-overwrite", "F", false, "Overwrite the profile if it already exists")
 
 	cmd.SetUsageTemplate(bootstrapUsage)
 
@@ -86,7 +89,7 @@ func bootstrapCmd(cmd *cobra.Command, args []string) error {
 
 	// Client Bootstrap will create the gort config if necessary, and append
 	// the new credentials to it.
-	user, err := gortClient.Bootstrap()
+	user, err := gortClient.Bootstrap(flagBootstrapOverwriteProfile)
 	if err != nil {
 		return err
 	}

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -116,7 +116,7 @@ func (c *GortClient) Authenticated() (bool, error) {
 }
 
 // Bootstrap calls the POST /v2/bootstrap endpoint.
-func (c *GortClient) Bootstrap() (rest.User, error) {
+func (c *GortClient) Bootstrap(overwrite bool) (rest.User, error) {
 	endpointURL := fmt.Sprintf("%s/v2/bootstrap", c.profile.URL)
 
 	// Get profile data so we can update it afterwards
@@ -125,7 +125,7 @@ func (c *GortClient) Bootstrap() (rest.User, error) {
 		return rest.User{}, err
 	}
 
-	if _, exists := profile.Profiles[c.profile.Name]; exists {
+	if _, exists := profile.Profiles[c.profile.Name]; exists && !overwrite {
 		return rest.User{}, fmt.Errorf("profile %s already exists", c.profile.Name)
 	}
 


### PR DESCRIPTION
The `gort bootstrap` command can now forcibly overwrite an existing profile if one by the same name already exists.

Example:

```
$ gort bootstrap -i localhost:80             
Error: profile localhost_80 already exists

$ gort bootstrap -iF localhost:80             
User "admin" created and credentials appended to gort config.
```