### PR TITLE
Wrap command responses in a generic envelope struct

### DIFF
--- a/adapter/slack/adapter.go
+++ b/adapter/slack/adapter.go
@@ -31,12 +31,14 @@ var (
 	linkMarkdownRegexLong  = regexp.MustCompile(`\<[^|:]*:[^|]*\|([^|]*)\>`)
 )
 
+const DefaultCommandTemplate = "```{{ .Response.Out }}```"
+
 const DefaultCommandErrorTemplate = "The pipeline failed planning the invocation:\n" +
 	"```{{ .Request.Bundle.Name }}:{{ .Request.Command.Name }} {{ .Request.Parameters }}```\n" +
 	"The specific error was:\n" +
 	"```{{ .Response.Out }}```"
 
-const DefaultMessageTemplate = "```{{ .Response.Out }}```"
+const DefaultMessageTemplate = "{{ .Response.Out }}"
 
 // NewAdapter will construct a SlackAdapter instance for a given provider configuration.
 func NewAdapter(provider data.SlackProvider) adapter.Adapter {

--- a/adapter/slack/adapter.go
+++ b/adapter/slack/adapter.go
@@ -31,6 +31,13 @@ var (
 	linkMarkdownRegexLong  = regexp.MustCompile(`\<[^|:]*:[^|]*\|([^|]*)\>`)
 )
 
+const DefaultCommandErrorTemplate = "The pipeline failed planning the invocation:\n" +
+	"```{{ .Request.Bundle.Name }}:{{ .Request.Command.Name }} {{ .Request.Parameters }}```\n" +
+	"The specific error was:\n" +
+	"```{{ .Response.Out }}```"
+
+const DefaultMessageTemplate = "```{{ .Response.Out }}```"
+
 // NewAdapter will construct a SlackAdapter instance for a given provider configuration.
 func NewAdapter(provider data.SlackProvider) adapter.Adapter {
 	if provider.APIToken != "" {
@@ -39,7 +46,7 @@ func NewAdapter(provider data.SlackProvider) adapter.Adapter {
 		client := slack.New(provider.APIToken)
 		rtm := client.NewRTM()
 
-		return ClassicAdapter{
+		return &ClassicAdapter{
 			client:   client,
 			provider: provider,
 			rtm:      rtm,

--- a/adapter/slack/classic_adapter.go
+++ b/adapter/slack/classic_adapter.go
@@ -17,10 +17,12 @@
 package slack
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
 	"strings"
+	"text/template"
 
 	"github.com/getgort/gort/adapter"
 	"github.com/getgort/gort/data"
@@ -386,44 +388,83 @@ func (s *ClassicAdapter) onRTMError(event *slack.RTMError, info *adapter.Info) *
 	)
 }
 
-// SendMessage will send a message (from the bot) into the specified channel.
-func (s ClassicAdapter) SendMessage(channelID string, text string) error {
-	_, _, err := s.rtm.PostMessage(
-		channelID,
-		slack.MsgOptionDisableMediaUnfurl(),
-		slack.MsgOptionAsUser(false),
-		slack.MsgOptionUsername(s.provider.BotName),
-		slack.MsgOptionText(text, false),
-		slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{
-			IconURL:  s.provider.IconURL,
-			Markdown: true,
-		}),
-	)
-
-	return err
+// SendErrorMessage sends an error message to a specified channel.
+func (s *ClassicAdapter) SendErrorMessage(channelID string, title string, text string) error {
+	e := data.NewCommandResponseEnvelope(data.CommandRequest{}, data.WithError(title, fmt.Errorf(text), 1))
+	return s.SendResponseEnvelope(channelID, e)
 }
 
-// SendErrorMessage will send a message (from the bot) into the specified channel.
-func (s ClassicAdapter) SendErrorMessage(channelID string, title string, text string) error {
-	_, _, err := s.rtm.PostMessage(
-		channelID,
-		slack.MsgOptionAttachments(
-			slack.Attachment{
-				Title:      title,
-				Text:       text,
-				Color:      "#FF0000",
-				MarkdownIn: []string{"text"},
-			},
-		),
+// SendMessage sends a standard output message to a specified channel.
+func (s *ClassicAdapter) SendMessage(channelID string, message string) error {
+	e := data.NewCommandResponseEnvelope(data.CommandRequest{}, data.WithResponseLines([]string{message}))
+	return s.SendResponseEnvelope(channelID, e)
+}
+
+// SendResponseEnvelope sends the contents of a response envelope to a
+// specified channel. If channelID is empty the value of
+// envelope.Request.ChannelID will be used.
+func (s *ClassicAdapter) SendResponseEnvelope(channelID string, envelope data.CommandResponseEnvelope) error {
+	var templateText string
+
+	if envelope.Data.IsError && envelope.Request.Bundle.Name != "" {
+		templateText = DefaultCommandErrorTemplate
+	} else {
+		templateText = DefaultMessageTemplate
+	}
+
+	t, err := template.New("envelope").Parse(templateText)
+	if err != nil {
+		return err
+	}
+
+	buffer := new(bytes.Buffer)
+
+	err = t.Execute(buffer, envelope)
+	if err != nil {
+		return err
+	}
+
+	options := []slack.MsgOption{
 		slack.MsgOptionDisableMediaUnfurl(),
-		slack.MsgOptionDisableMarkdown(),
 		slack.MsgOptionAsUser(false),
 		slack.MsgOptionUsername(s.provider.BotName),
 		slack.MsgOptionPostMessageParameters(slack.PostMessageParameters{
 			IconURL:  s.provider.IconURL,
 			Markdown: true,
 		}),
-	)
+	}
+
+	if channelID == "" {
+		channelID = envelope.Request.ChannelID
+	}
+
+	if envelope.Data.IsError {
+		title := envelope.Response.Title
+		if title == "" {
+			title = "Error"
+		}
+
+		options = append(
+			options,
+			slack.MsgOptionAttachments(
+				slack.Attachment{
+					Title:      title,
+					Text:       buffer.String(),
+					Color:      "#FF0000",
+					MarkdownIn: []string{"text"},
+				},
+			),
+		)
+
+	} else {
+		options = append(
+			options,
+			slack.MsgOptionDisableMediaUnfurl(),
+			slack.MsgOptionText(buffer.String(), false),
+		)
+	}
+
+	_, _, err = s.client.PostMessage(channelID, options...)
 
 	return err
 }

--- a/cli/hidden-command.go
+++ b/cli/hidden-command.go
@@ -86,8 +86,7 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 	} else if len(ss) == 1 {
 		cmdName = ss[0]
 	} else {
-		fmt.Println("Invalid command syntax: expected <bundle:command> or <command>.")
-		return nil
+		return fmt.Errorf("invalid command syntax: expected <bundle:command> or <command>")
 	}
 
 	var found bool
@@ -125,8 +124,7 @@ func detailCommand(gortClient *client.GortClient, command string) error {
 	}
 
 	if !found {
-		fmt.Printf("Command not found: %v\n", command)
-		return nil
+		return fmt.Errorf("command not found: %v", command)
 	}
 
 	return nil

--- a/data/bundle.go
+++ b/data/bundle.go
@@ -17,9 +17,6 @@
 package data
 
 import (
-	"context"
-	"fmt"
-	"strings"
 	"time"
 )
 
@@ -64,51 +61,4 @@ type BundleCommand struct {
 	LongDescription string   `yaml:"long_description,omitempty" json:"long_description,omitempty"`
 	Name            string   `yaml:"-" json:"-"`
 	Rules           []string `yaml:",omitempty" json:"rules,omitempty"`
-}
-
-// CommandEntry conveniently wraps a bundle and one command within that bundle.
-type CommandEntry struct {
-	Bundle  Bundle
-	Command BundleCommand
-}
-
-// CommandRequest represents a user command request as triggered in (probably)
-// a chat provider.
-type CommandRequest struct {
-	CommandEntry
-	Adapter    string          // The name of the adapter this request originated from.
-	ChannelID  string          // The provider ID of the channel that the request originated in.
-	Context    context.Context // The request context
-	Parameters []string        // Tokenized command parameters
-	RequestID  int64           // A unique requestID
-	Timestamp  time.Time       // The time this request was triggered
-	UserID     string          // The provider ID of user making this request.
-	UserEmail  string          // The email address associated with the user making the request
-	UserName   string          // The gort username of the user making the request
-}
-
-// CommandString is a convenience method that outputs the normalized command
-// string, more or less as the user typed it.
-func (r CommandRequest) CommandString() string {
-	return fmt.Sprintf(
-		"%s:%s %s",
-		r.Bundle.Name,
-		r.Command.Name,
-		strings.Join(r.Parameters, " "))
-}
-
-// CommandResponse is returned by a relay to indicate that a command has been executed.
-// It includes the original CommandRequest, the command's exit status code, and
-// the commands entire stdout as a slice of lines. Title can be used to build
-// a user output message, and generally contains a short description of the result.
-//
-// TODO Add a request ID that correcponds with the request, so that we can more
-// directly link it back to its user and adapter of origin.
-type CommandResponse struct {
-	Command  CommandRequest
-	Duration time.Duration
-	Status   int64
-	Title    string   // Command Error
-	Output   []string // Contents of the commands stdout.
-	Error    error
 }

--- a/data/command.go
+++ b/data/command.go
@@ -30,19 +30,25 @@ type CommandEntry struct {
 	Command BundleCommand
 }
 
+type CommandParameters []string
+
+func (c CommandParameters) String() string {
+	return strings.Join(c, " ")
+}
+
 // CommandRequest represents a user command request as triggered in (probably)
 // a chat provider.
 type CommandRequest struct {
 	CommandEntry
-	Adapter    string          // The name of the adapter this request originated from
-	ChannelID  string          // The provider ID of the channel that the request originated in
-	Context    context.Context // The request context
-	Parameters []string        // Tokenized command parameters
-	RequestID  int64           // A unique requestID
-	Timestamp  time.Time       // The time this request was triggered
-	UserID     string          // The provider ID of user making this request
-	UserEmail  string          // The email address associated with the user making the request
-	UserName   string          // The gort username of the user making the request
+	Adapter    string            // The name of the adapter this request originated from
+	ChannelID  string            // The provider ID of the channel that the request originated in
+	Context    context.Context   // The request context
+	Parameters CommandParameters // Tokenized command parameters
+	RequestID  int64             // A unique requestID
+	Timestamp  time.Time         // The time this request was triggered
+	UserID     string            // The provider ID of user making this request
+	UserEmail  string            // The email address associated with the user making the request
+	UserName   string            // The gort username of the user making the request
 }
 
 // CommandString is a convenience method that outputs the normalized command
@@ -159,7 +165,6 @@ func WithError(title string, err error, code int16) CommandResponseEnvelopeOptio
 // WithResponseLines sets Response.Lines and Response.Out.
 func WithResponseLines(r []string) CommandResponseEnvelopeOption {
 	return func(e *CommandResponseEnvelope) {
-
 		e.Response.Lines = r
 		e.Response.Out = strings.Join(r, "\n")
 		e.Response.Payload, e.Response.IsStructured = unmarshalResponsePayload(e.Response.Out)

--- a/data/command.go
+++ b/data/command.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CommandEntry conveniently wraps a bundle and one command within that bundle.
+type CommandEntry struct {
+	Bundle  Bundle
+	Command BundleCommand
+}
+
+// CommandRequest represents a user command request as triggered in (probably)
+// a chat provider.
+type CommandRequest struct {
+	CommandEntry
+	Adapter    string          // The name of the adapter this request originated from.
+	ChannelID  string          // The provider ID of the channel that the request originated in.
+	Context    context.Context // The request context
+	Parameters []string        // Tokenized command parameters
+	RequestID  int64           // A unique requestID
+	Timestamp  time.Time       // The time this request was triggered
+	UserID     string          // The provider ID of user making this request.
+	UserEmail  string          // The email address associated with the user making the request
+	UserName   string          // The gort username of the user making the request
+}
+
+// CommandString is a convenience method that outputs the normalized command
+// string, more or less as the user typed it.
+func (r CommandRequest) CommandString() string {
+	return fmt.Sprintf(
+		"%s:%s %s",
+		r.Bundle.Name,
+		r.Command.Name,
+		strings.Join(r.Parameters, " "))
+}
+
+type CommandResponse struct {
+	// IsStructured is true if the command output is structured as JSON? If
+	// so, then it will be unmarshalled as Payload; else Payload will be a
+	// string (equal to Out).
+	IsStructured bool
+
+	// Title includes a title. Usually only set by the relay for certain
+	// internally-detected errors. It can be used to build a user output
+	// message, and generally contains a short description of the result.
+	Title string
+
+	// Lines contains the command output (from both stdout and stderr) as
+	// a string slice, delimitted along newlines.
+	Lines []string
+
+	// Out The command output as a single block of text, with lines joined
+	// with newlines.
+	Out string
+
+	// Payload includes the command output. If the output is structured JSON,
+	// it will be unmarshalled and placed here where it can be accessible to
+	// Go templates. If it's not, this will be a string equal to Out.
+	Payload interface{}
+}
+
+// CommandResponseData contains about the command execution, including its
+// duration and exit code. If the relay set an an explicit error, it will
+// be here as well.
+type CommandResponseData struct {
+	// Duration is how long the command required to execute.
+	// TODO(mtitmus) What are the start and endpoints? Do we want to track
+	// multiple durations for "famework time" and "command time" and whatever
+	// else?
+	Duration time.Duration
+
+	// ExitCode is the exit code reported by the command.
+	ExitCode int16
+
+	// IsError is a convenience flag that's set to true if ExitCode isn't 0.
+	IsError bool
+
+	// Error can be set by the relay in certain internal error conditions.
+	// TODO(mtitmus) Do we even need this? Will it be confusing?
+	Error error
+}
+
+// CommandResponseEnvelope encapsulates the data and metadata around a command
+// execution and response. It's returned by a relay when a command has been
+// executed. It is passed directly into the response formatter where it can be
+// accessed by the Go templates that describe the response formats.
+// https://play.golang.org/p/tYe4zc0E1cB
+type CommandResponseEnvelope struct {
+	// Request is the original request used to execute the command. It contains
+	// the original CommandEntry value as well as the user and adapter data.
+	Request CommandRequest
+
+	// Response contains the
+	Response CommandResponse
+
+	// Data contains about the command execution, including its duration and exit code.
+	// If the relay set an an explicit error, it will be here as well.
+	Data CommandResponseData
+}
+
+func NewCommandResponseEnvelope(request CommandRequest, opts ...CommandResponseEnvelopeOption) CommandResponseEnvelope {
+	envelope := CommandResponseEnvelope{
+		Request:  request,
+		Response: CommandResponse{Lines: []string{}},
+	}
+
+	for _, o := range opts {
+		o(&envelope)
+	}
+
+	return envelope
+}
+
+type CommandResponseEnvelopeOption func(e *CommandResponseEnvelope)
+
+// WithExitCode sets Data.ExitCode and Data.IsError
+func WithExitCode(code int16) CommandResponseEnvelopeOption {
+	return func(e *CommandResponseEnvelope) {
+		e.Data.ExitCode = code
+		e.Data.IsError = code != 0
+	}
+}
+
+// WithError sets e.Data.Error, Data.ExitCode, Data.IsError, Response.Lines,
+// Response.Out, and Response.Title.
+func WithError(title string, err error, code int16) CommandResponseEnvelopeOption {
+	return func(e *CommandResponseEnvelope) {
+		e.Data.Error = err
+		e.Data.ExitCode = code
+		e.Data.IsError = code != 0
+		e.Response.Lines = []string{err.Error()}
+		e.Response.Out = err.Error()
+		e.Response.Title = title
+	}
+}
+
+// WithResponseLines sets Response.Lines and Response.Out.
+func WithResponseLines(r []string) CommandResponseEnvelopeOption {
+	return func(e *CommandResponseEnvelope) {
+		e.Response.Lines = r
+		e.Response.Out = strings.Join(r, "\n")
+	}
+}

--- a/data/command_test.go
+++ b/data/command_test.go
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var request = CommandRequest{
+	RequestID: 1,
+	UserName:  "user",
+}
+
+func TestNewCommandResponseEnvelope(t *testing.T) {
+	e := NewCommandResponseEnvelope(request)
+
+	assert.Equal(t, int64(1), e.Request.RequestID)
+	assert.Equal(t, "user", e.Request.UserName)
+}
+
+func TestNewCommandResponseEnvelope_WithExitCode0(t *testing.T) {
+	e := NewCommandResponseEnvelope(request, WithExitCode(0))
+
+	assert.Equal(t, int16(0), e.Data.ExitCode)
+	assert.False(t, e.Data.IsError)
+}
+
+func TestNewCommandResponseEnvelope_WithExitCode1(t *testing.T) {
+	e := NewCommandResponseEnvelope(request, WithExitCode(1))
+
+	assert.Equal(t, int16(1), e.Data.ExitCode)
+	assert.True(t, e.Data.IsError)
+}
+
+func TestNewCommandResponseEnvelope_WithError(t *testing.T) {
+	const title = "Error"
+	const msg = "this is an error"
+	const code int16 = 1
+	err := fmt.Errorf(msg)
+
+	e := NewCommandResponseEnvelope(request, WithError(title, err, code))
+
+	assert.Equal(t, e.Data.Error, err)
+	assert.Equal(t, e.Data.ExitCode, code)
+	assert.True(t, e.Data.IsError)
+	assert.Equal(t, e.Response.Lines, []string{msg})
+	assert.Equal(t, e.Response.Out, msg)
+	assert.Equal(t, e.Response.Payload, msg)
+	assert.Equal(t, e.Response.Title, title)
+}
+
+func TestNewCommandResponseEnvelope_WithResponseLines(t *testing.T) {
+	message := "this is a\ntwo-line message"
+	lines := []string{"this is a", "two-line message"}
+
+	e := NewCommandResponseEnvelope(request, WithResponseLines(lines))
+
+	assert.Equal(t, e.Response.Lines, lines)
+	assert.Equal(t, e.Response.Out, message)
+	assert.False(t, e.Response.IsStructured)
+	assert.Equal(t, e.Response.Payload, message)
+	assert.False(t, e.Data.IsError)
+}
+
+func TestNewCommandResponseEnvelope_WithStructuredResponseLines(t *testing.T) {
+	message := `{ "Name": "Matt" }`
+	lines := []string{message}
+
+	e := NewCommandResponseEnvelope(request, WithResponseLines(lines))
+
+	assert.Equal(t, e.Response.Lines, lines)
+	assert.Equal(t, e.Response.Out, message)
+	assert.True(t, e.Response.IsStructured)
+	assert.False(t, e.Data.IsError)
+
+	p, ok := e.Response.Payload.(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "Matt", p["Name"])
+}

--- a/dataaccess/dataaccess.go
+++ b/dataaccess/dataaccess.go
@@ -35,7 +35,7 @@ type DataAccess interface {
 	RequestBegin(ctx context.Context, request *data.CommandRequest) error
 	RequestUpdate(ctx context.Context, request data.CommandRequest) error
 	RequestError(ctx context.Context, request data.CommandRequest, err error) error
-	RequestClose(ctx context.Context, result data.CommandResponse) error
+	RequestClose(ctx context.Context, result data.CommandResponseEnvelope) error
 
 	BundleCreate(ctx context.Context, bundle data.Bundle) error
 	BundleDelete(ctx context.Context, name string, version string) error

--- a/dataaccess/memory/request-access.go
+++ b/dataaccess/memory/request-access.go
@@ -67,12 +67,12 @@ func (da *InMemoryDataAccess) RequestUpdate(ctx context.Context, result data.Com
 }
 
 // Will not implement
-func (da *InMemoryDataAccess) RequestClose(ctx context.Context, result data.CommandResponse) error {
+func (da *InMemoryDataAccess) RequestClose(ctx context.Context, envelope data.CommandResponseEnvelope) error {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
 	_, sp := tr.Start(ctx, "memory.RequestClose")
 	defer sp.End()
 
-	if result.Command.RequestID == 0 {
+	if envelope.Request.RequestID == 0 {
 		return fmt.Errorf("command request ID unset")
 	}
 

--- a/dataaccess/memory/request-access_test.go
+++ b/dataaccess/memory/request-access_test.go
@@ -112,13 +112,7 @@ func testRequestClose(t *testing.T) {
 		UserName:     "testUserName ",
 	}
 
-	res := data.CommandResponse{
-		Command:  req,
-		Duration: time.Second,
-		Status:   1,
-		Error:    fmt.Errorf("Fake error"),
-	}
-
-	err = da.RequestClose(ctx, res)
+	env := data.NewCommandResponseEnvelope(req, data.WithError("", fmt.Errorf("Fake error"), 1))
+	err = da.RequestClose(ctx, env)
 	assert.NoError(t, err)
 }

--- a/dataaccess/postgres/request-access_test.go
+++ b/dataaccess/postgres/request-access_test.go
@@ -112,13 +112,7 @@ func testRequestClose(t *testing.T) {
 		UserName:     "testUserName ",
 	}
 
-	res := data.CommandResponse{
-		Command:  req,
-		Duration: time.Second,
-		Status:   1,
-		Error:    fmt.Errorf("Fake error"),
-	}
-
-	err = da.RequestClose(ctx, res)
+	env := data.NewCommandResponseEnvelope(req, data.WithError("", fmt.Errorf("Fake error"), 1))
+	err = da.RequestClose(ctx, env)
 	assert.NoError(t, err)
 }

--- a/relay/exitcodes.go
+++ b/relay/exitcodes.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package relay
+
+// Most of the follow exit codes were borrowed from sysexits.h.
+
+const (
+	// ExitOK represents a successful termination.
+	ExitOK = 0
+
+	// ExitGeneral is catchall for otherwise unspecified errors.
+	ExitGeneral = 1
+
+	// ExitNoUser represents a "user unknown" error.
+	ExitNoUser = 67
+
+	// ExitNoRelay represents "relay name unknown" error.
+	ExitNoRelay = 68
+
+	// ExitUnavailable represents a "relay unavailable" error.
+	ExitUnavailable = 69
+
+	// ExitInternalError represents an internal software error. It's returned
+	// if a command has a failure that's detectable by the framework.
+	ExitInternalError = 70
+
+	// ExitSystemErr represents a system (Gort) error (for example, it can't
+	// spawn a worker).
+	ExitSystemErr = 71
+
+	// ExitTimeout represents a timeout exceeded.
+	ExitTimeout = 72
+
+	// ExitIoErr represents an input/output error.
+	ExitIoErr = 74
+
+	// ExitTempFail represents a temporary failure. The user can retry.
+	ExitTempFail = 75
+
+	// ExitProtocol represents a remote error in protocol.
+	ExitProtocol = 76
+
+	// ExitNoPerm represents a permission denied.
+	ExitNoPerm = 77
+
+	// ExitCannotInvoke represents that the invoked command cannot execute.
+	// TODO(mtitmus) What does this mean, exactly?
+	ExitCannotInvoke = 126
+
+	// ExitCommandNotFound represents that the command can't be found.
+	ExitCommandNotFound = 127
+)

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -18,6 +18,8 @@ package relay
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -33,24 +35,6 @@ import (
 	"github.com/getgort/gort/worker"
 )
 
-const (
-	// Most exit codes borrowed from sysexits.h
-	ExitOK              = 0   // successful termination
-	ExitGeneral         = 1   // catchall for errors
-	ExitNoUser          = 67  // user unknown
-	ExitNoRelay         = 68  // relay name unknown
-	ExitUnavailable     = 69  // relay unavailable
-	ExitInternalError   = 70  // internal software error
-	ExitSystemErr       = 71  // system error (e.g., can't spawn worker)
-	ExitTimeout         = 72  // timeout exceeded
-	ExitIoErr           = 74  // input/output error
-	ExitTempFail        = 75  // temp failure; user can retry
-	ExitProtocol        = 76  // remote error in protocol
-	ExitNoPerm          = 77  // permission denied
-	ExitCannotInvoke    = 126 //  Command invoked cannot execute
-	ExitCommandNotFound = 127 // "command not found"
-)
-
 // AuthorizeUser is not yet implemented, and will not be until remote relays
 // become a thing. For now, all authentication is done by the command execution
 // framework (which, in turn, invokes a/the relay).
@@ -60,9 +44,9 @@ func AuthorizeUser(commandRequest data.CommandRequest, user rest.User) (bool, er
 }
 
 // StartListening instructs the relay to begin listening for incoming command requests.
-func StartListening() (chan<- data.CommandRequest, <-chan data.CommandResponse) {
+func StartListening() (chan<- data.CommandRequest, <-chan data.CommandResponseEnvelope) {
 	commandRequests := make(chan data.CommandRequest)
-	commandResponses := make(chan data.CommandResponse)
+	commandResponses := make(chan data.CommandResponseEnvelope)
 
 	go func() {
 		for commandRequest := range commandRequests {
@@ -116,86 +100,92 @@ func getUser(ctx context.Context, username string) (rest.User, error) {
 // up after worker processes. It receives incoming command requests from the
 // StartListening() CommandRequest channel, returning a CommandResponse which
 // in turn gets forwarded to that function's CommandRequest channel.
-func handleRequest(ctx context.Context, commandRequest data.CommandRequest) data.CommandResponse {
+func handleRequest(ctx context.Context, request data.CommandRequest) data.CommandResponseEnvelope {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
 	ctx, sp := tr.Start(ctx, "relay.handleRequest")
 	defer sp.End()
 
-	response := data.CommandResponse{
-		Command: commandRequest,
-		Output:  []string{},
+	var envelope data.CommandResponseEnvelope
+
+	da, err := dataaccess.Get()
+	if err != nil {
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Failed to access data access layer", err, ExitIoErr),
+		)
+		envelope.Data.Duration = time.Since(envelope.Request.Timestamp)
+		return envelope
 	}
 
-	user, err := getUser(ctx, commandRequest.UserName)
+	defer func() {
+		envelope.Data.Duration = time.Since(envelope.Request.Timestamp)
+		da.RequestClose(ctx, envelope)
+	}()
+
+	user, err := getUser(ctx, request.UserName)
+
 	switch {
 	case err == nil:
 		break
 	case gerrs.Is(err, errs.ErrNoSuchUser):
-		response.Status = ExitNoUser
-		response.Error = err
-		response.Title = "No such Gort user: " + commandRequest.UserName
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("No such Gort user: "+request.UserName, err, ExitNoUser),
+		)
+		return envelope
 	case gerrs.Is(err, errs.ErrDataAccess):
-		response.Status = ExitIoErr
-		response.Error = err
-		response.Title = "Data access failure"
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Data access failure", err, ExitIoErr),
+		)
+		return envelope
 	default:
-		response.Status = ExitGeneral
-		response.Error = err
-		response.Title = "Failed to get Gort user: " + commandRequest.UserName
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Failed to get Gort user: "+request.UserName, err, ExitGeneral),
+		)
+		return envelope
 	}
 
-	if authorized, err := AuthorizeUser(commandRequest, user); err != nil {
-		response.Status = ExitGeneral
-		response.Error = err
-		response.Title = "Authorization system failure"
-		response.Output = []string{err.Error()}
-		return response
+	if authorized, err := AuthorizeUser(request, user); err != nil {
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Authorization system failure", err, ExitSystemErr),
+		)
+		return envelope
 	} else if !authorized {
-		response.Status = ExitNoPerm
-		response.Error = err
-		response.Title = "Permission denied"
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Permission denied", err, ExitNoPerm),
+		)
+		return envelope
 	}
 
-	worker, err := SpawnWorker(ctx, commandRequest)
+	worker, err := SpawnWorker(ctx, request)
 	if err != nil {
-		response.Status = ExitSystemErr
-		response.Error = err
-		response.Title = "Failed to spawn worker"
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Failed to spawn worker", err, ExitSystemErr),
+		)
+		return envelope
 	}
 
-	response = runWorker(ctx, worker, response)
-	response.Duration = time.Since(response.Command.Timestamp)
+	envelope = runWorker(ctx, worker, request)
 
-	da, err := dataaccess.Get()
-	if err != nil {
-		response.Status = ExitIoErr
-		response.Error = err
-		response.Title = "Failed to access data access layer"
-		response.Output = []string{err.Error()}
-		return response
-	}
-
-	da.RequestClose(ctx, response)
-
-	return response
+	return envelope
 }
 
 // runWorker is called by handleRequest to do the work of starting an
 // individual worker, capturing its output, and cleaning up after it.
-func runWorker(ctx context.Context, worker worker.Worker, response data.CommandResponse) data.CommandResponse {
+func runWorker(ctx context.Context, worker worker.Worker, request data.CommandRequest) data.CommandResponseEnvelope {
 	tr := otel.GetTracerProvider().Tracer(telemetry.ServiceName)
 	_, sp := tr.Start(ctx, "relay.runWorker")
 	defer sp.End()
+
+	var envelope data.CommandResponseEnvelope
+	defer func() {
+		envelope.Data.Duration = time.Since(envelope.Request.Timestamp)
+	}()
 
 	// Get configured timeout. Zero (or less) is no timeout.
 	var cancel context.CancelFunc
@@ -208,48 +198,62 @@ func runWorker(ctx context.Context, worker worker.Worker, response data.CommandR
 
 	stdoutChan, err := worker.Start(ctx)
 	if err != nil {
-		response.Status = ExitSystemErr
-		response.Error = err
-		response.Title = "Failed to start worker"
-		response.Output = []string{err.Error()}
-		return response
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError("Failed to start worker", err, ExitSystemErr),
+		)
+		return envelope
 	}
 
 	// Read input from the worker until the stream closes
+	var lines []string
 	for line := range stdoutChan {
-		response.Output = append(response.Output, line)
+		lines = append(lines, line)
 	}
 
-	select {
-	case response.Status = <-worker.Stopped():
-		if response.Status != ExitOK {
-			response.Title = "Command Error"
+	var exitCode int64
 
-			if len(response.Output) == 0 {
-				response.Output = []string{"Unknown error executing command"}
+	select {
+	case exitCode = <-worker.Stopped():
+		var opts []data.CommandResponseEnvelopeOption
+
+		if exitCode != ExitOK {
+			if len(lines) == 0 {
+				lines = []string{"Unknown error executing command"}
 			}
+
+			opts = append(opts, data.WithError(
+				"Command Error",
+				fmt.Errorf(strings.Join(lines, " ")),
+				int16(exitCode),
+			))
 		}
 
+		opts = append(opts, data.WithResponseLines(lines))
+		envelope = data.NewCommandResponseEnvelope(request, opts...)
+
 		log.
-			WithField("request.id", response.Command.RequestID).
-			WithField("status", response.Status).
+			WithField("request.id", request.RequestID).
+			WithField("status", exitCode).
 			Info("Command exited")
 
 	case <-ctx.Done():
 		err := ctx.Err()
-		response.Status = ExitTimeout
-		response.Error = err
-		response.Title = err.Error()
+
+		envelope = data.NewCommandResponseEnvelope(
+			request,
+			data.WithError(err.Error(), err, ExitTimeout),
+		)
 
 		log.
 			WithError(err).
-			WithField("request.id", response.Command.RequestID).
-			WithField("status", response.Status).
+			WithField("request.id", request.RequestID).
+			WithField("status", ExitTimeout).
 			Info("Command exited with error")
 	}
 
 	forceTerm := time.Second * 10
 	worker.Stop(ctx, &forceTerm)
 
-	return response
+	return envelope
 }


### PR DESCRIPTION
This is the first step in the implementation of output formatting. Included structural changes:

* Added `CommandResponseEnvelope` struct. This contains the complete context around a command execution, including the `CommandRequest`, `CommandResponse`, and some basic metadata about the command execution.
* Previously, responses from command processes were provided by a `CommandResponse` value. This has been replaced by the `CommandResponseEnvelope`.
* Many functions have been updated to accept `CommandResponseEnvelope` values instead of whatever they were accepting before.
* A `SendResponseEnvelope` function has been added to the `Adapter` interface.
* All command formatting has been removed from `adapter/adapter.go` and into the three adapter implementations. They even (technically) use default templates! 

The next step is to move formatting logic -- which will accept `CommandResponseEnvelope` values to the adapters. Formatting directives will be describable in the Bundle, and will support the use of Go template syntax to inject values from the `CommandResponseEnvelope`.

There are no functional changes. All behavior remains the same.