### PR TITLE
[trivial] Bug fix for unresolvable `self-signed certificate detected` client message

### DIFF
--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -52,7 +52,7 @@ func (c *GortClient) Authenticate() (rest.Token, error) {
 		return rest.Token{}, gerrs.Wrap(gerrs.ErrMarshal, err)
 	}
 
-	resp, err := http.Post(endpointURL, "application/json", bytes.NewBuffer(postBytes))
+	resp, err := c.client.Post(endpointURL, "application/json", bytes.NewBuffer(postBytes))
 	switch {
 	case err == nil:
 	case strings.Contains(err.Error(), "certificate"):


### PR DESCRIPTION
Bug fix for unresolvable `self-signed certificate detected` message.

Just forgot to use custom client in one spot! Oops!