### PR TITLE
Add fallback text to output elements

### DIFF
--- a/adapter/discord/adapter.go
+++ b/adapter/discord/adapter.go
@@ -266,6 +266,9 @@ func (s *Adapter) Send(ctx context.Context, channelID string, elements templates
 		case *templates.Section:
 			// Ignore sections entirely in Discord.
 
+		case *templates.Alt:
+			// Ignore Alt, only rendered as fallback
+
 		case *templates.Text:
 			var title = t.Title
 			var text = t.Text
@@ -309,6 +312,12 @@ func (s *Adapter) Send(ctx context.Context, channelID string, elements templates
 	return err
 }
 
+// SendText sends a simple text message to the specified channel.
+func (s *Adapter) SendText(ctx context.Context, channelID string, message string) error {
+	_, err := s.session.ChannelMessageSend(channelID, message)
+	return err
+}
+
 // SendError is a break-glass error message function that's used when the
 // templating function fails somehow. Obviously, it does not utilize the
 // templating engine.
@@ -326,7 +335,6 @@ func (s *Adapter) SendError(ctx context.Context, channelID string, title string,
 	}
 
 	_, err = s.session.ChannelMessageSendEmbed(channelID, embed)
-
 	return err
 }
 

--- a/adapter/slack/classic_adapter.go
+++ b/adapter/slack/classic_adapter.go
@@ -292,6 +292,11 @@ func (s *ClassicAdapter) Send(ctx context.Context, channelID string, elements te
 	return Send(ctx, s.client, s, channelID, elements)
 }
 
+// SendText sends a simple text message to the specified channel.
+func (s *ClassicAdapter) SendText(ctx context.Context, channelID string, message string) error {
+	return SendText(ctx, s.client, s, channelID, message)
+}
+
 // SendError is a break-glass error message function that's used when the
 // templating function fails somehow. Obviously, it does not utilize the
 // templating engine.

--- a/adapter/slack/socketmode_adapter.go
+++ b/adapter/slack/socketmode_adapter.go
@@ -213,6 +213,11 @@ func (s *SocketModeAdapter) Send(ctx context.Context, channelID string, elements
 	return Send(ctx, s.client, s, channelID, elements)
 }
 
+// SendText sends a simple text message to the specified channel.
+func (s *SocketModeAdapter) SendText(ctx context.Context, channelID string, message string) error {
+	return SendText(ctx, s.client, s, channelID, message)
+}
+
 // SendError is a break-glass error message function that's used when the
 // templating function fails somehow. Obviously, it does not utilize the
 // templating engine.

--- a/bundles/bundle_test.go
+++ b/bundles/bundle_test.go
@@ -37,7 +37,7 @@ func TestLoadBundleFromFile(t *testing.T) {
 	assert.Len(t, b.Permissions, 1)
 	assert.Equal(t, "ubuntu", b.Docker.Image)
 	assert.Equal(t, "20.04", b.Docker.Tag)
-	assert.Len(t, b.Commands, 1)
+	assert.Len(t, b.Commands, 4)
 
 	// Bundle templates
 	assert.Equal(t, "Template:Bundle:CommandError", b.Templates.CommandError)

--- a/templates/functions.go
+++ b/templates/functions.go
@@ -56,6 +56,12 @@ func FunctionMap() template.FuncMap {
 
 		// Simple blocks
 		"divider": functions.DividerFunction,
+
+		// Alternative text
+		"alt": functions.AltFunction,
+
+		// Unimplemented - for testing fallback behavior
+		"unimplemented": functions.UnimplementedFunction,
 	}
 
 	sprigFuncs := sprig.FuncMap()

--- a/templates/functions_alt.go
+++ b/templates/functions_alt.go
@@ -16,18 +16,21 @@
 
 package templates
 
-type Divider struct {
+// Alt provides alternative text to be shown if other elements in a message cannot be rendered.
+// Only the first instance of Alt will be shown.
+type Alt struct {
 	Tag
+	Text string
 }
 
-func (o *Divider) String() string {
+func (o *Alt) String() string {
 	return encodeTag(*o)
 }
 
-func (o *Divider) Alt() string {
-	return "==="
+func (o *Alt) Alt() string {
+	return o.Text
 }
 
-func (f *Functions) DividerFunction() *Divider {
-	return &Divider{}
+func (f *Functions) AltFunction(content string) *Alt {
+	return &Alt{Text: content}
 }

--- a/templates/functions_header.go
+++ b/templates/functions_header.go
@@ -35,6 +35,10 @@ func (o *Header) String() string {
 	return encodeTag(*o)
 }
 
+func (o *Header) Alt() string {
+	return o.Title
+}
+
 func (f *Functions) HeaderFunction() *Header {
 	return &Header{}
 }

--- a/templates/functions_image.go
+++ b/templates/functions_image.go
@@ -28,6 +28,10 @@ func (o *Image) String() string {
 	return encodeTag(*o)
 }
 
+func (o *Image) Alt() string {
+	return o.URL
+}
+
 func (f *Functions) ImageFunction(url string) *Image {
 	return &Image{URL: url}
 }

--- a/templates/functions_section.go
+++ b/templates/functions_section.go
@@ -16,6 +16,8 @@
 
 package templates
 
+import "fmt"
+
 type Section struct {
 	Tag
 	Text   *Text           `json:",omitempty"`
@@ -24,6 +26,17 @@ type Section struct {
 
 func (o *Section) String() string {
 	return encodeTag(*o)
+}
+
+func (o *Section) Alt() string {
+	var out string
+	if o.Text != nil {
+		out = o.Text.Text
+	}
+	for _, element := range o.Fields {
+		out = fmt.Sprintf("%v\n\n%v", out, element.Alt())
+	}
+	return out
 }
 
 func (f *Functions) SectionFunction() *Section {
@@ -36,6 +49,10 @@ type SectionEnd struct {
 
 func (o *SectionEnd) String() string {
 	return encodeTag(*o)
+}
+
+func (o *SectionEnd) Alt() string {
+	return ""
 }
 
 func (f *Functions) SectionEndFunction() *SectionEnd {

--- a/templates/functions_section.go
+++ b/templates/functions_section.go
@@ -34,7 +34,9 @@ func (o *Section) Alt() string {
 		out = o.Text.Text
 	}
 	for _, element := range o.Fields {
-		out = fmt.Sprintf("%v\n\n%v", out, element.Alt())
+		if a, isAlt := element.(WithAlt); isAlt {
+			out = fmt.Sprintf("%v\n\n%v", out, a.Alt())
+		}
 	}
 	return out
 }

--- a/templates/functions_text.go
+++ b/templates/functions_text.go
@@ -30,6 +30,10 @@ func (o *Text) String() string {
 	return encodeTag(*o)
 }
 
+func (o *Text) Alt() string {
+	return o.Text
+}
+
 func (f *Functions) TextFunction() *Text {
 	return &Text{
 		Emoji:    true,
@@ -63,6 +67,10 @@ type TextEnd struct {
 
 func (o *TextEnd) String() string {
 	return encodeTag(*o)
+}
+
+func (o *TextEnd) Alt() string {
+	return ""
 }
 
 func (f *Functions) TextEndFunction() *TextEnd {

--- a/templates/functions_unimplemented.go
+++ b/templates/functions_unimplemented.go
@@ -26,10 +26,6 @@ func (o *Unimplemented) String() string {
 	return encodeTag(*o)
 }
 
-func (o *Unimplemented) Alt() string {
-	return "Unimplemented Element"
-}
-
 func (f *Functions) UnimplementedFunction() *Unimplemented {
 	return &Unimplemented{}
 }

--- a/templates/functions_unimplemented.go
+++ b/templates/functions_unimplemented.go
@@ -16,18 +16,20 @@
 
 package templates
 
-type Divider struct {
+// Unimplemented is an OutputElement that should not be implemented by any chat adapters.
+// It may be used when testing to force a fallback to alt text.
+type Unimplemented struct {
 	Tag
 }
 
-func (o *Divider) String() string {
+func (o *Unimplemented) String() string {
 	return encodeTag(*o)
 }
 
-func (o *Divider) Alt() string {
-	return "==="
+func (o *Unimplemented) Alt() string {
+	return "Unimplemented Element"
 }
 
-func (f *Functions) DividerFunction() *Divider {
-	return &Divider{}
+func (f *Functions) UnimplementedFunction() *Unimplemented {
+	return &Unimplemented{}
 }

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -30,6 +30,9 @@ type OutputElement interface {
 	First() int
 	Last() int
 	String() string
+}
+
+type WithAlt interface {
 	Alt() string
 }
 
@@ -55,7 +58,9 @@ func (o *OutputElements) Alt() string {
 		case *Alt:
 			return t.Text
 		default:
-			out = fmt.Sprintf("%v\n\n%v", out, element.Alt())
+			if a, isAlt := element.(WithAlt); isAlt {
+				out = fmt.Sprintf("%v\n\n%v", out, a.Alt())
+			}
 		}
 	}
 	return out

--- a/testing/test-bundle.yml
+++ b/testing/test-bundle.yml
@@ -39,3 +39,39 @@ commands:
       command_error: 'Template:Command:CommandError'
       message: 'Template:Command:Message'
       message_error: 'Template:Command:MessageError'
+  echoa:
+    description: "Write arguments to the standard output. Accessible to all users"
+    long_description: |-
+      Write arguments to the standard output.
+
+      Usage:
+        test:echox [string ...]
+    executable: [ "/bin/echo" ]
+    rules:
+      - allow
+    templates:
+      command: '{{ text }}{{ .Response.Out }}{{ endtext }}'
+      command_error: 'Template:Command:CommandError'
+      message: 'Template:Command:Message'
+      message_error: 'Template:Command:MessageError'
+  noalt:
+    description: "Returns a message with an unrenderable tag, forcing alt text formed from element text."
+    executable: [ "/bin/echo" ]
+    rules:
+      - allow
+    templates:
+      command: '{{ text }}{{ .Response.Out }}{{ endtext }}{{ unimplemented }}'
+      command_error: 'Template:Command:CommandError'
+      message: 'Template:Command:Message'
+      message_error: 'Template:Command:MessageError'
+  alt:
+    description: "Returns a message with an unrenderable tag, forcing the alt tag to be rendered."
+    executable: [ "/bin/echo" ]
+    rules:
+      - allow
+    templates:
+      command: '{{ text }}{{ .Response.Out }}{{ endtext }}{{ unimplemented }}{{ alt "alt text" }}'
+      command_error: 'Template:Command:CommandError'
+      message: 'Template:Command:Message'
+      message_error: 'Template:Command:MessageError'
+  


### PR DESCRIPTION
Fixes #150

Tested with updates to test-bundle.yml

Adds two new template tags: "unimplemented" which should not be handled by adapters to allow testing fallback to alt text, and "alt" which allows a template to specify its alternate text explicitly.

If "alt" is not provided, a concatenation of all element text is output as the fallback, separated by empty lines.