### PR TITLE
Make it easier to know who you are

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -404,8 +404,8 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 					"account for you, or your chat handle has not been " +
 					"registered. Currently, only registered users can " +
 					"interact with me.\n\nYou'll need a Gort administrator " +
-					"to map your Gort to the adapter (%s) and chat user " +
-					"ID (%s)."
+					"to map your Gort user to the adapter (%s) and chat " +
+					"user ID (%s)."
 
 				msg = fmt.Sprintf(msg, id.Adapter.GetName(), id.ChatUser.ID)
 				SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "No Such Account", msg)

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -400,13 +400,16 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 		if id.GortUser, autocreated, err = findOrMakeGortUser(ctx, id.Adapter, id.ChatUser); err != nil {
 			switch {
 			case gerrs.Is(err, ErrSelfRegistrationOff):
-				msg := "I'm terribly sorry, but either I don't " +
-					"have a Gort account for you, or your Slack chat handle has " +
-					"not been registered. Currently, only registered users can " +
-					"interact with me.\n\n\nYou'll need to ask a Gort " +
-					"administrator to fix this situation and to register your " +
-					"Slack handle."
+				msg := "I'm terribly sorry, but either I don't have a Gort " +
+					"account for you, or your chat handle has not been " +
+					"registered. Currently, only registered users can " +
+					"interact with me.\n\nYou'll need a Gort administrator " +
+					"to map your Gort to the adapter (%s) and chat user " +
+					"ID (%s)."
+
+				msg = fmt.Sprintf(msg, id.Adapter.GetName(), id.ChatUser.ID)
 				SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "No Such Account", msg)
+
 			case gerrs.Is(err, ErrGortNotBootstrapped):
 				msg := "Gort doesn't appear to have been bootstrapped yet! Please " +
 					"use `gort bootstrap` to properly bootstrap the Gort " +

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -406,7 +406,6 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 					"interact with me.\n\nYou'll need a Gort administrator " +
 					"to map your Gort user to the adapter (%s) and chat " +
 					"user ID (%s)."
-
 				msg = fmt.Sprintf(msg, id.Adapter.GetName(), id.ChatUser.ID)
 				SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "No Such Account", msg)
 
@@ -415,6 +414,7 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 					"use `gort bootstrap` to properly bootstrap the Gort " +
 					"environment before proceeding."
 				SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "Not Bootstrapped?", msg)
+
 			default:
 				msg := "An unexpected error has occurred"
 				SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "Error", msg)

--- a/bundles/default.yml
+++ b/bundles/default.yml
@@ -138,3 +138,14 @@ commands:
     executable: [ "/bin/gort", "hidden", "command" ]
     rules:
       - allow
+
+  whoami:
+    description: "Provides your basic identity and account information"
+    long_description: |-
+      Provides your basic identity and account information.
+
+      Usage:
+        gort:whoami
+    executable: [ "/bin/gort", "hidden", "whoami" ]
+    rules:
+      - allow

--- a/cli/hidden-whoami.go
+++ b/cli/hidden-whoami.go
@@ -67,8 +67,6 @@ func hiddenWhoamiCmd(cmd *cobra.Command, args []string) error {
 
 	if gortUser = os.Getenv("GORT_USER"); gortUser == "" {
 		gortUser = "*UNDEFINED!*"
-	} else if gortUser == "nobody" {
-		gortUser = "Nobody"
 	}
 
 	tmpl := `Adapter:   %s

--- a/cli/hidden-whoami.go
+++ b/cli/hidden-whoami.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	hiddenWhoamiUse   = "whoami"
+	hiddenWhoamiShort = "Provides your basic identity and account information"
+	hiddenWhoamiLong  = `Provides your basic identity and account information.`
+	hiddenWhoamiUsage = `Usage:
+	!gort:whoami
+
+  Flags:
+	-h, --help   Show this message and exit
+  `
+)
+
+// GetHiddenWhoamiCmd is a command
+func GetHiddenWhoamiCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          hiddenWhoamiUse,
+		Short:        hiddenWhoamiShort,
+		Long:         hiddenWhoamiLong,
+		RunE:         hiddenWhoamiCmd,
+		SilenceUsage: true,
+	}
+
+	cmd.SetUsageTemplate(hiddenWhoamiUsage)
+
+	return cmd
+}
+
+func hiddenWhoamiCmd(cmd *cobra.Command, args []string) error {
+	if _, ok := os.LookupEnv("GORT_SERVICE_TOKEN"); !ok {
+		return fmt.Errorf("whoami can only be run from chat")
+	}
+
+	var adapter, chatUserID, gortUser string
+
+	if adapter = os.Getenv("GORT_ADAPTER"); adapter == "" {
+		adapter = "*UNDEFINED!*"
+	}
+
+	if chatUserID = os.Getenv("GORT_CHAT_ID"); chatUserID == "" {
+		chatUserID = "*UNDEFINED!*"
+	}
+
+	if gortUser = os.Getenv("GORT_USER"); gortUser == "" {
+		gortUser = "*UNDEFINED!*"
+	} else if gortUser == "nobody" {
+		gortUser = "Nobody"
+	}
+
+	tmpl := `Adapter:   %s
+User ID:   %s
+Mapped to: %s
+`
+
+	fmt.Printf(tmpl, adapter, chatUserID, gortUser)
+	return nil
+}

--- a/cli/hidden.go
+++ b/cli/hidden.go
@@ -36,6 +36,7 @@ func GetHiddenCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(GetHiddenCommandCmd())
+	cmd.AddCommand(GetHiddenWhoamiCmd())
 
 	return cmd
 }

--- a/cli/user-info.go
+++ b/cli/user-info.go
@@ -96,7 +96,7 @@ Groups     %s
 			"user to one or more chat provider IDs.")
 	} else {
 		var keys []string
-		for k, _ := range user.Mappings {
+		for k := range user.Mappings {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys)

--- a/testing/test-default.yml
+++ b/testing/test-default.yml
@@ -138,3 +138,14 @@ commands:
     executable: [ "/bin/gort", "hidden", "commands" ]
     rules:
       - allow
+
+  whoami:
+    description: "Provides your basic identity and account information"
+    long_description: |-
+      Provides your basic identity and account information.
+
+      Usage:
+        gort:whoami
+    executable: [ "/bin/gort", "hidden", "whoami" ]
+    rules:
+      - allow

--- a/worker/docker/worker.go
+++ b/worker/docker/worker.go
@@ -233,13 +233,15 @@ func (w *ContainerWorker) envVars() []string {
 	env := []string{}
 
 	vars := map[string]string{
+		`GORT_ADAPTER`:       w.command.Adapter,
 		`GORT_BUNDLE`:        w.command.Bundle.Name,
 		`GORT_COMMAND`:       w.command.Command.Name,
-		`GORT_CHAT_HANDLE`:   w.command.UserID,
+		`GORT_CHAT_ID`:       w.command.UserID,
 		`GORT_INVOCATION_ID`: fmt.Sprintf("%d", w.command.RequestID),
 		`GORT_ROOM`:          w.command.ChannelID,
 		`GORT_SERVICE_TOKEN`: w.token.Token,
 		`GORT_SERVICES_ROOT`: config.GetGortServerConfigs().APIURLBase,
+		`GORT_USER`:          w.command.UserName,
 	}
 
 	for k, v := range vars {

--- a/worker/kubernetes/worker.go
+++ b/worker/kubernetes/worker.go
@@ -251,13 +251,15 @@ func (w *KubernetesWorker) envVars(ctx context.Context) ([]corev1.EnvVar, error)
 	}
 
 	vars := map[string]string{
+		`GORT_ADAPTER`:       w.command.Adapter,
 		`GORT_BUNDLE`:        w.command.Bundle.Name,
 		`GORT_COMMAND`:       w.command.Command.Name,
-		`GORT_CHAT_HANDLE`:   w.command.UserID,
+		`GORT_CHAT_ID`:       w.command.UserID,
 		`GORT_INVOCATION_ID`: fmt.Sprintf("%d", w.command.RequestID),
 		`GORT_ROOM`:          w.command.ChannelID,
 		`GORT_SERVICE_TOKEN`: w.token.Token,
 		`GORT_SERVICES_ROOT`: fmt.Sprintf("%s:%d", gortIP, gortPort),
+		`GORT_USER`:          w.command.UserName,
 	}
 
 	var env []corev1.EnvVar


### PR DESCRIPTION
Before, it was difficult to find the correct adapter name and chat user ID to do a `gort user map`.

This makes two changes:

* Creates a `gort:whoami` command that any registered user can run. 
* The error message the unregistered users (when account autocreate is off) now includes the adapter ID and chat user ID.

Before account mapping:

```
User:
!whoami

Gort:
No Such Account
I'm terribly sorry, but either I don't have a Gort account for you, or your chat handle has
not been registered. Currently, only registered users can interact with me.

You'll need a Gort administrator to map your Gort user to the adapter (Gort) and chat
user ID (U023P412345).
```

After mapping to the `admin` Gort account.

```
User:
!whoami

Gort:
Adapter:   Gort
User ID:   U023P412345
Mapped to: admin
```