### PR TITLE
Fix bundle enable and info commands

### DIFF
--- a/cli/bundle-info.go
+++ b/cli/bundle-info.go
@@ -18,6 +18,7 @@ package cli
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/getgort/gort/client"
@@ -85,30 +86,33 @@ func doBundleInfoAll(name string) error {
 		return err
 	}
 
-	var enabled *data.Bundle
-	var versions = make([]string, 0)
+	var enabled data.Bundle
+	var versions []string
 
 	for _, bundle := range bundles {
 		versions = append(versions, bundle.Version)
 
 		if bundle.Enabled {
-			enabled = &bundle
+			enabled = bundle
 		}
 	}
 
 	fmt.Printf("Name: %s\n", name)
 	fmt.Printf("Versions: %s\n", strings.Join(versions, ", "))
 
-	if enabled != nil {
+	if enabled.Version != "" {
 		fmt.Println("Status: Enabled")
 		fmt.Printf("Enabled Version: %s\n", enabled.Version)
 
-		commands := make([]string, 0)
+		var commands []string
 		for name := range enabled.Commands {
 			commands = append(commands, name)
 		}
 
+		sort.Strings(commands)
 		fmt.Printf("Commands: %s\n", strings.Join(commands, ", "))
+
+		sort.Strings(enabled.Permissions)
 		fmt.Printf("Permissions: %s\n", strings.Join(enabled.Permissions, ", "))
 	} else {
 		fmt.Println("Status: Disabled")
@@ -134,7 +138,7 @@ func doBundleInfoVersion(name, version string) error {
 	if bundle.Enabled {
 		fmt.Println("Status: Enabled")
 	} else {
-		fmt.Println("Status: Enabled")
+		fmt.Println("Status: Not Enabled")
 	}
 
 	commands := make([]string, 0)

--- a/client/client-bundle.go
+++ b/client/client-bundle.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sort"
 
 	"github.com/getgort/gort/data"
 )
@@ -138,6 +139,9 @@ func (c *GortClient) BundleListVersions(bundlename string) ([]data.Bundle, error
 	if err != nil {
 		return []data.Bundle{}, err
 	}
+
+	// Always sort by version
+	sort.Slice(bundles, func(i, j int) bool { return bundles[i].Semver().LessThan(bundles[j].Semver()) })
 
 	return bundles, nil
 }

--- a/data/bundle.go
+++ b/data/bundle.go
@@ -17,7 +17,10 @@
 package data
 
 import (
+	"strings"
 	"time"
+
+	"github.com/coreos/go-semver/semver"
 )
 
 // BundleInfo wraps a minimal amount of data about a bundle.
@@ -46,6 +49,24 @@ type Bundle struct {
 	Commands          map[string]*BundleCommand `yaml:",omitempty" json:"commands,omitempty"`
 	Default           bool                      `yaml:"-" json:"default,omitempty"`
 	Templates         Templates                 `yaml:",omitempty" json:"templates,omitempty"`
+}
+
+func (b Bundle) Semver() semver.Version {
+	var version = b.Version
+
+	if version == "" {
+		return semver.Version{}
+	}
+
+	if strings.ToLower(version)[0] == 'v' {
+		version = version[1:]
+	}
+
+	if v, err := semver.NewVersion(version); err != nil {
+		return semver.Version{}
+	} else {
+		return *v
+	}
 }
 
 // BundleCommand represents a bundle command, as defined in the "bundles/commands"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/bwmarrin/discordgo v0.23.2
 	github.com/containerd/containerd v1.5.8 // indirect
+	github.com/coreos/go-semver v0.3.0
 	github.com/docker/docker v20.10.11+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/go-git/go-git/v5 v5.4.2

--- a/go.sum
+++ b/go.sum
@@ -255,6 +255,7 @@ github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmeka
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20161114122254-48702e0da86b/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=


### PR DESCRIPTION
Fixed `bundle enable` command to behave as per its description by automatically enabling the highest version bundle if the bundle version is omitted.

Fixed `bundle info` to correctly display installed bundle status.

The `data.Bundle` struct now knows how to return a `semver.Version` struct corresponding to its version.