### PR TITLE
Fix some annoying token timeout behavior

### DIFF
--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -94,7 +94,7 @@ func bootstrapCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("User %q created and credentials appended to gort config.\n", user.Username)
+	fmt.Printf("User %q created and credentials appended to Gort config.\n", user.Username)
 
 	return nil
 }

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -188,6 +188,11 @@ func (c *GortClient) Bootstrap(overwrite bool) (rest.User, error) {
 		return user, err
 	}
 
+	// Delete any old tokens that may be laying around
+	if err := c.deleteHostToken(); err != nil {
+		return user, nil
+	}
+
 	return user, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -198,6 +198,21 @@ func NewClient(entry ProfileEntry) (*GortClient, error) {
 	}, nil
 }
 
+// deleteHostToken attempts to delete an existing token file.
+func (c *GortClient) deleteHostToken() error {
+	tokenFileName, err := c.getGortTokenFilename()
+	if err != nil {
+		return gerrs.Wrap(gerrs.ErrIO, err)
+	}
+
+	// File doesn't exist. Not an error.
+	if _, err := os.Stat(tokenFileName); err != nil {
+		return nil
+	}
+
+	return os.Remove(tokenFileName)
+}
+
 func (c *GortClient) doRequest(method string, url string, body []byte) (*http.Response, error) {
 	token, err := c.Token()
 	if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -294,7 +294,7 @@ func handleAuthenticate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := dataAccessLayer.TokenGenerate(r.Context(), username, 10*time.Minute)
+	token, err := dataAccessLayer.TokenGenerate(r.Context(), username, 10*time.Second)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return


### PR DESCRIPTION
Fixes #169 

* When bootstrapping, any existing tokens for that same service are deleted. 
* Tokens generated by the service now have a lifetime of 10 seconds.

```bash
# Old token exists
$ ls ~/.gort/tokens                            
total 8
-rw-r--r--  1 matt  staff  179 Nov 19 13:02 localhost_4000_localhost_4000

# Bootstrap should clean old token up
$ gort bootstrap -iF https://localhost:4000     
User "admin" created and credentials appended to Gort config.

# It does!
$ ls ~/.gort/tokens 
total 0

# An action should generate a new token
$ gort user list
USER NAME   FULL NAME            EMAIL            
admin       Gort Administrator   gort@localhost   

# It does!
$ ls ~/.gort/tokens                      
total 8
-rw-r--r--  1 matt  staff  179 Nov 19 13:02 localhost_4000_localhost_4000
```