### PR TITLE
Fixed crash on empty command bug

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -455,6 +455,18 @@ func TriggerCommand(ctx context.Context, rawCommand string, id RequestorIdentity
 		return nil, fmt.Errorf("command tokenization error: %w", err)
 	}
 
+	if len(tokens) == 0 {
+		msg := "Empty command received. Did you forget something?"
+		SendErrorMessage(ctx, id.Adapter, id.ChatChannel.ID, "Empty Command", msg)
+
+		err := fmt.Errorf("command had no tokens")
+		da.RequestError(ctx, request, err)
+		telemetry.Errors().WithError(err).Commit(ctx)
+		le.WithError(err).Error("Command request had no tokens")
+
+		return nil, err
+	}
+
 	le = le.WithField("command.name", tokens[0]).
 		WithField("command.params", strings.Join(tokens[1:], " "))
 


### PR DESCRIPTION
Fixed a crash that occurred if a registered user typed the command trigger (`!`) with no command.

Panic contained the following:

```
panic: runtime error: index out of range [0] with length 0

goroutine 85 [running]:
panic({0x19fa260, 0xc00055d008})
     /usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/getgort/gort/adapter.TriggerCommand({0x1d96b18, 0xc000791440}, {0x2b1d148, 0x0}, {{0x1dc43a8, 0xc00033d3b0}, 0xc0009835f0, 0xc0008c5c00, 0xc0004a04b0})
     /gort/adapter/adapter.go:458 +0x3a76
```

Tested successfully with patch by replicating error condition; received the expected error message.