### PR TITLE
WIP: allow kubernetes Secrets to be injected into the worker's environment

### DIFF
--- a/data/bundle.go
+++ b/data/bundle.go
@@ -109,6 +109,7 @@ type BundleCommand struct {
 // BundleKubernetes represents the "bundles/kubernetes" subsection of the config doc
 type BundleKubernetes struct {
 	ServiceAccountName string `yaml:"serviceAccountName,omitempty" json:"serviceAccountName,omitempty"`
+	EnvSecret          string `yaml:"env_secret,omitempty" json:"env_secret,omitempty"`
 }
 
 // CoerceVersionToSemver takes a version number and attempts to coerce it

--- a/dataaccess/postgres/bundle-access.go
+++ b/dataaccess/postgres/bundle-access.go
@@ -833,14 +833,14 @@ func (da PostgresDataAccess) doBundleGetCommandTemplates(ctx context.Context, tx
 }
 
 func (da PostgresDataAccess) doBundleGetKubernetes(ctx context.Context, tx *sql.Tx, bundleName, bundleVersion string) (data.BundleKubernetes, error) {
-	query := `SELECT service_account_name
+	query := `SELECT service_account_name, env_secret
 		FROM bundle_kubernetes
 		WHERE bundle_name=$1 AND bundle_version=$2`
 
 	var kubernetes data.BundleKubernetes
 
 	err := tx.QueryRowContext(ctx, query, bundleName, bundleVersion).
-		Scan(&kubernetes.ServiceAccountName)
+		Scan(&kubernetes.ServiceAccountName, &kubernetes.EnvSecret)
 
 	switch {
 	case err == sql.ErrNoRows:
@@ -1055,11 +1055,11 @@ func (da PostgresDataAccess) doBundleInsertTemplates(ctx context.Context, tx *sq
 
 func (da PostgresDataAccess) doBundleInsertKubernetes(ctx context.Context, tx *sql.Tx, bundle data.Bundle) error {
 	query := `INSERT INTO bundle_kubernetes
-		(bundle_name, bundle_version, service_account_name)
-		VALUES ($1, $2, $3);`
+		(bundle_name, bundle_version, service_account_name, env_secret)
+		VALUES ($1, $2, $3, $4);`
 
 	_, err := tx.ExecContext(ctx, query, bundle.Name, bundle.Version,
-		bundle.Kubernetes.ServiceAccountName)
+		bundle.Kubernetes.ServiceAccountName, bundle.Kubernetes.EnvSecret)
 
 	if err != nil {
 		if strings.Contains(err.Error(), "violates") {

--- a/dataaccess/postgres/postgres-data-access.go
+++ b/dataaccess/postgres/postgres-data-access.go
@@ -470,7 +470,7 @@ func (da PostgresDataAccess) createUsersTable(ctx context.Context, db *sql.DB) e
 	var err error
 
 	createUserQuery := `CREATE TABLE users (
-		email         	TEXT UNIQUE NOT NULL,
+		email         	TEXT,
 		full_name     	TEXT,
 		password_hash 	TEXT,
 		username 		TEXT PRIMARY KEY

--- a/dataaccess/postgres/postgres-data-access.go
+++ b/dataaccess/postgres/postgres-data-access.go
@@ -363,7 +363,8 @@ func (da PostgresDataAccess) createBundleKubernetesTables(ctx context.Context, d
 	createBundlesQuery := `CREATE TABLE bundle_kubernetes (
 		bundle_version 			TEXT NOT NULL,
 		bundle_name				TEXT NOT NULL,
-		service_account_name 	TEXT NOT NULL
+		service_account_name 	TEXT NOT NULL,
+		env_secret            TEXT NOT NULL
 	);
 	`
 

--- a/worker/kubernetes/worker.go
+++ b/worker/kubernetes/worker.go
@@ -200,6 +200,19 @@ func (w *KubernetesWorker) buildJobData(ctx context.Context) (*batchv1.Job, erro
 		return nil, err
 	}
 
+	secretEnv := []corev1.EnvFromSource{}
+
+	if w.command.Bundle.Kubernetes.EnvSecret != "" {
+		secretEnv = append(secretEnv, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: w.command.Bundle.Kubernetes.EnvSecret,
+				},
+			},
+		},
+		)
+	}
+
 	job := &batchv1.Job{
 		TypeMeta: metav1.TypeMeta{APIVersion: "batch/v1", Kind: "Job"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -222,6 +235,7 @@ func (w *KubernetesWorker) buildJobData(ctx context.Context) (*batchv1.Job, erro
 							Command: w.entryPoint,
 							Args:    w.commandParameters,
 							Env:     envVars,
+							EnvFrom: secretEnv,
 						},
 					},
 					RestartPolicy: corev1.RestartPolicyNever,


### PR DESCRIPTION
As stated, this should probably be considered a WIP, it's only been implemented for postgres, and ideally it would let you 1) mount multiple secrets into the environment, and 2) mount Secrets into the worker's filesystem. this currently provides the functionality I need to use this bot in a more production'y manor right now, but I may circle back to do more work on it if time allows, and if it's not the totally wrong direction for this kind of thing that folks have envisioned for the project.