### PR TITLE
Add Dynamic Configuration REST methods to service

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Gort MVP To-Do
+# Gort Version 1.0 To-Do
 
 An incomplete list of tasks for Gort by milestone. Tasks listed within a milestone are mostly unordered.
 
@@ -54,6 +54,26 @@ This is ABSOLUTELY NOT an exhaustive list. Please feel free to add to it. If wha
 
 **_(Publicly release v0.8.0-alpha.0 at this point)_**
 
-## Milestone 9 (TBD)
+## Milestone 9 (Output Format Templating) -- _COMPLETE!_ ✅
 
-- TBD
+- This feature allows you to control the look and feel (and, to some degree, content) of any information sent to users in a chat-agnostic way.
+- Add colors, images, or other text formatting to your command (a future release will add buttons to chat providers that support it.
+- Both Gort system messages and command output message may be customized (within the constraints imposed by a given chat provider).
+- Templates can be defined at the application configuration level, the bundle level, and even the individual command level. Or you can just use the defaults. They're fine.
+- JSON objects output by commands are easily accessible.
+- For more information about Templates, see the official documentation.
+
+## Milestone 10 (Triggers; Dynamic Configuration) -- _In progress!_
+
+- Triggers
+  - Allow Gort to execute existing bundled commands in response to non-command chat input.
+- Dynamic Configuration
+  - Configuration values will be securely stored in Gort (more specifically, in a secure secret storage backend, such as Hashicorp Vault).
+  - Values will be able to be associated with specific bundles and/or roles/users.
+  - Appropriate values will be injected into worker containers as either environment variables or files.
+
+## Milestone 11 (Custom webhooks)
+
+- Expose custom (auth-gated) RESTful endpoints that can be used to execute existing bundled commands.
+
+### NOTE: Future milestones may be re-prioritized at any time.

--- a/bundles/default.yml
+++ b/bundles/default.yml
@@ -14,6 +14,7 @@ long_description: |-
 
 permissions:
   - manage_commands
+  - manage_configs
   - manage_groups
   - manage_roles
   - manage_users
@@ -43,6 +44,26 @@ commands:
     executable: [ "/bin/gort", "bundle" ]
     rules:
       - must have gort:manage_commands
+
+  config:
+    description: "Get or set dynamic configurations"
+    long_description: |-
+      Allows you to perform bundle administration.
+
+      Usage:
+        gort:config [command]
+
+      Available Commands:
+        delete      Delete an existing dynamic configuration
+        get         Get a dynamic configuration by key
+        list        List configurations for a particular bundle
+        set         Set a dynamic configuration
+
+      Flags:
+        -h, --help   help for config
+    executable: [ "/bin/gort", "config" ]
+    rules:
+      - must have gort:manage_configs
 
   group:
     description: "Manage Cog user groups"

--- a/bundles/default.yml
+++ b/bundles/default.yml
@@ -155,7 +155,7 @@ commands:
 
       Usage:
         gort:help [flags] [command]
-    executable: [ "/bin/gort", "hidden", "command" ]
+    executable: [ "/bin/gort", "hidden", "commands" ]
     rules:
       - allow
 

--- a/config/config.go
+++ b/config/config.go
@@ -128,6 +128,14 @@ func GetDockerConfigs() data.DockerConfigs {
 	return config.DockerConfigs
 }
 
+// GetDynamicConfigs returns the data wrapper for the "dynamic" config section.
+func GetDynamicConfigs() data.DynamicConfigs {
+	configMutex.RLock()
+	defer configMutex.RUnlock()
+
+	return config.DynamicConfigs
+}
+
 // GetGlobalConfigs returns the data wrapper for the "global" config section.
 func GetGlobalConfigs() data.GlobalConfigs {
 	configMutex.RLock()

--- a/data/config.go
+++ b/data/config.go
@@ -24,6 +24,7 @@ type GortConfig struct {
 	GlobalConfigs     GlobalConfigs     `yaml:"global,omitempty"`
 	DatabaseConfigs   DatabaseConfigs   `yaml:"database,omitempty"`
 	DockerConfigs     DockerConfigs     `yaml:"docker,omitempty"`
+	DynamicConfigs    DynamicConfigs    `yaml:"dynamic_configuration,omitempty"`
 	JaegerConfigs     JaegerConfigs     `yaml:"jaeger,omitempty"`
 	KubernetesConfigs KubernetesConfigs `yaml:"kubernetes,omitempty"`
 	SlackProviders    []SlackProvider   `yaml:"slack,omitempty"`
@@ -65,6 +66,11 @@ type DatabaseConfigs struct {
 type DockerConfigs struct {
 	DockerHost string `yaml:"host,omitempty"`
 	Network    string `yaml:"network,omitempty"`
+}
+
+// DynamicConfigs is the data wrapper for the "dynamic_configuration" section.
+type DynamicConfigs struct {
+	Backend string `yaml:"backend,omitempty"`
 }
 
 // JaegerConfigs is the data wrapper for the "jaeger" section.

--- a/dynamic/dal/dal_dynamic.go
+++ b/dynamic/dal/dal_dynamic.go
@@ -37,10 +37,6 @@ type DALDynamicConfiguration struct {
 	da dataaccess.DataAccess
 }
 
-func (c *DALDynamicConfiguration) Create(ctx context.Context, config data.DynamicConfiguration) error {
-	return c.da.DynamicConfigurationCreate(ctx, config)
-}
-
 func (c *DALDynamicConfiguration) Delete(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) error {
 	return c.da.DynamicConfigurationDelete(ctx, layer, bundle, owner, key)
 }
@@ -55,4 +51,19 @@ func (c *DALDynamicConfiguration) Get(ctx context.Context, layer data.Configurat
 
 func (c *DALDynamicConfiguration) List(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) ([]data.DynamicConfiguration, error) {
 	return c.da.DynamicConfigurationList(ctx, layer, bundle, owner, key)
+}
+
+func (c *DALDynamicConfiguration) Set(ctx context.Context, config data.DynamicConfiguration) error {
+	exists, err := c.Exists(ctx, config.Layer, config.Bundle, config.Owner, config.Key)
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if err := c.Delete(ctx, config.Layer, config.Bundle, config.Owner, config.Key); err != nil {
+			return err
+		}
+	}
+
+	return c.da.DynamicConfigurationCreate(ctx, config)
 }

--- a/dynamic/dal/dal_dynamic.go
+++ b/dynamic/dal/dal_dynamic.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getgort/gort/data"
+	"github.com/getgort/gort/dataaccess"
+)
+
+func NewDALDynamicConfiguration(data.DynamicConfigs) (*DALDynamicConfiguration, error) {
+	da, err := dataaccess.Get()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create DAL-based dynamic config: %w", err)
+	}
+
+	return &DALDynamicConfiguration{da: da}, nil
+}
+
+type DALDynamicConfiguration struct {
+	da dataaccess.DataAccess
+}
+
+func (c *DALDynamicConfiguration) Create(ctx context.Context, config data.DynamicConfiguration) error {
+	return c.da.DynamicConfigurationCreate(ctx, config)
+}
+
+func (c *DALDynamicConfiguration) Delete(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) error {
+	return c.da.DynamicConfigurationDelete(ctx, layer, bundle, owner, key)
+}
+
+func (c *DALDynamicConfiguration) Exists(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (bool, error) {
+	return c.da.DynamicConfigurationExists(ctx, layer, bundle, owner, key)
+}
+
+func (c *DALDynamicConfiguration) Get(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (data.DynamicConfiguration, error) {
+	return c.da.DynamicConfigurationGet(ctx, layer, bundle, owner, key)
+}
+
+func (c *DALDynamicConfiguration) List(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) ([]data.DynamicConfiguration, error) {
+	return c.da.DynamicConfigurationList(ctx, layer, bundle, owner, key)
+}

--- a/dynamic/dynamic.go
+++ b/dynamic/dynamic.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dynamic
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/getgort/gort/config"
+	"github.com/getgort/gort/data"
+	"github.com/getgort/gort/dynamic/dal"
+)
+
+// DynamicConfiguration is the interface used to interact with the dynamic
+// configuration backend.
+type DynamicConfiguration interface {
+	Create(ctx context.Context, config data.DynamicConfiguration) error
+	Delete(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) error
+	Exists(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (bool, error)
+	Get(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (data.DynamicConfiguration, error)
+	List(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) ([]data.DynamicConfiguration, error)
+}
+
+// Get provides an interface to the dynamic configuration backend. If no
+// backend is specified, the default (DAL) implementation is used.
+func Get() (DynamicConfiguration, error) {
+	dynamicConfigs := config.GetDynamicConfigs()
+
+	if config.IsUndefined(dynamicConfigs) {
+		return dal.NewDALDynamicConfiguration(dynamicConfigs)
+	}
+
+	return nil, fmt.Errorf("unsupported dynamic configuration backend: %s", dynamicConfigs.Backend)
+}

--- a/dynamic/dynamic.go
+++ b/dynamic/dynamic.go
@@ -28,11 +28,11 @@ import (
 // DynamicConfiguration is the interface used to interact with the dynamic
 // configuration backend.
 type DynamicConfiguration interface {
-	Create(ctx context.Context, config data.DynamicConfiguration) error
 	Delete(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) error
 	Exists(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (bool, error)
 	Get(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) (data.DynamicConfiguration, error)
 	List(ctx context.Context, layer data.ConfigurationLayer, bundle, owner, key string) ([]data.DynamicConfiguration, error)
+	Set(ctx context.Context, config data.DynamicConfiguration) error
 }
 
 // Get provides an interface to the dynamic configuration backend. If no

--- a/service/config-handlers.go
+++ b/service/config-handlers.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/getgort/gort/data"
-	"github.com/getgort/gort/dataaccess"
+	"github.com/getgort/gort/dynamic"
 	gerrs "github.com/getgort/gort/errors"
 )
 
@@ -46,7 +46,7 @@ func getDynamicConfigParameters(params map[string]string) (layer data.Configurat
 
 // handleDeleteDynamicConfig handles "DELETE /v2/configs/{groupname}"
 func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
-	dataAccessLayer, err := dataaccess.Get()
+	dc, err := dynamic.Get()
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -58,7 +58,7 @@ func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = dataAccessLayer.DynamicConfigurationDelete(r.Context(), layer, bundle, owner, key)
+	err = dc.Delete(r.Context(), layer, bundle, owner, key)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -67,7 +67,7 @@ func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
 
 // handleGetDynamicConfig handles "GET /v2/configs/{groupname}"
 func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
-	dataAccessLayer, err := dataaccess.Get()
+	dc, err := dynamic.Get()
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -79,7 +79,7 @@ func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	exists, err := dataAccessLayer.DynamicConfigurationExists(r.Context(), layer, bundle, owner, key)
+	exists, err := dc.Exists(r.Context(), layer, bundle, owner, key)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -89,7 +89,7 @@ func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configs, err := dataAccessLayer.DynamicConfigurationGet(r.Context(), layer, bundle, owner, key)
+	configs, err := dc.Get(r.Context(), layer, bundle, owner, key)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -100,7 +100,7 @@ func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
 
 // handleGetDynamicConfigs handles "GET /v2/configs"
 func handleGetDynamicConfigs(w http.ResponseWriter, r *http.Request) {
-	dataAccessLayer, err := dataaccess.Get()
+	dc, err := dynamic.Get()
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -112,7 +112,7 @@ func handleGetDynamicConfigs(w http.ResponseWriter, r *http.Request) {
 	owner := params[ParameterConfigurationOwner]
 	key := params[ParameterConfigurationKey]
 
-	configs, err := dataAccessLayer.DynamicConfigurationList(r.Context(), layer, bundle, owner, key)
+	configs, err := dc.List(r.Context(), layer, bundle, owner, key)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -123,7 +123,7 @@ func handleGetDynamicConfigs(w http.ResponseWriter, r *http.Request) {
 
 // handlePutDynamicConfiguration handles "PUT /v2/configs/{groupname}"
 func handlePutDynamicConfiguration(w http.ResponseWriter, r *http.Request) {
-	dataAccessLayer, err := dataaccess.Get()
+	dc, err := dynamic.Get()
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return
@@ -147,21 +147,21 @@ func handlePutDynamicConfiguration(w http.ResponseWriter, r *http.Request) {
 	c.Owner = owner
 	c.Key = key
 
-	exists, err := dataAccessLayer.DynamicConfigurationExists(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
+	exists, err := dc.Exists(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
 	if err != nil {
 		respondAndLogError(r.Context(), w, gerrs.ErrUnmarshal)
 		return
 	}
 
 	if exists {
-		err = dataAccessLayer.DynamicConfigurationDelete(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
+		err = dc.Delete(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
 		if err != nil {
 			respondAndLogError(r.Context(), w, err)
 			return
 		}
 	}
 
-	err = dataAccessLayer.DynamicConfigurationCreate(r.Context(), c)
+	err = dc.Create(r.Context(), c)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return

--- a/service/config-handlers.go
+++ b/service/config-handlers.go
@@ -44,7 +44,7 @@ func getDynamicConfigParameters(params map[string]string) (layer data.Configurat
 	return
 }
 
-// handleDeleteDynamicConfig handles "DELETE /v2/configs/{groupname}"
+// handleDeleteDynamicConfig handles "DELETE /v2/configs/{bundle}/{layer}/{owner}/{key}"
 func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
 	dc, err := dynamic.Get()
 	if err != nil {
@@ -65,7 +65,7 @@ func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleGetDynamicConfig handles "GET /v2/configs/{groupname}"
+// handleGetDynamicConfig handles "GET /v2/configs/{bundle}/{layer}/{owner}/{key}"
 func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
 	dc, err := dynamic.Get()
 	if err != nil {
@@ -121,7 +121,7 @@ func handleGetDynamicConfigs(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(configs)
 }
 
-// handlePutDynamicConfiguration handles "PUT /v2/configs/{groupname}"
+// handlePutDynamicConfiguration handles "PUT /v2/configs/{bundle}/{layer}/{owner}/{key}"
 func handlePutDynamicConfiguration(w http.ResponseWriter, r *http.Request) {
 	dc, err := dynamic.Get()
 	if err != nil {

--- a/service/config-handlers.go
+++ b/service/config-handlers.go
@@ -147,21 +147,7 @@ func handlePutDynamicConfiguration(w http.ResponseWriter, r *http.Request) {
 	c.Owner = owner
 	c.Key = key
 
-	exists, err := dc.Exists(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
-	if err != nil {
-		respondAndLogError(r.Context(), w, gerrs.ErrUnmarshal)
-		return
-	}
-
-	if exists {
-		err = dc.Delete(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
-		if err != nil {
-			respondAndLogError(r.Context(), w, err)
-			return
-		}
-	}
-
-	err = dc.Create(r.Context(), c)
+	err = dc.Set(r.Context(), c)
 	if err != nil {
 		respondAndLogError(r.Context(), w, err)
 		return

--- a/service/config-handlers.go
+++ b/service/config-handlers.go
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/getgort/gort/data"
+	"github.com/getgort/gort/dataaccess"
+	gerrs "github.com/getgort/gort/errors"
+)
+
+const (
+	ParameterConfigurationLayer  = "layer"
+	ParameterConfigurationBundle = "bundle"
+	ParameterConfigurationOwner  = "owner"
+	ParameterConfigurationKey    = "key"
+)
+
+func getDynamicConfigParameters(params map[string]string) (layer data.ConfigurationLayer, bundle string, owner string, key string, err error) {
+	layer = data.ConfigurationLayer(params[ParameterConfigurationLayer])
+	bundle = params[ParameterConfigurationBundle]
+	owner = params[ParameterConfigurationOwner]
+	key = params[ParameterConfigurationKey]
+	err = layer.Validate()
+	return
+}
+
+// handleDeleteDynamicConfig handles "DELETE /v2/configs/{groupname}"
+func handleDeleteDynamicConfig(w http.ResponseWriter, r *http.Request) {
+	dataAccessLayer, err := dataaccess.Get()
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	layer, bundle, owner, key, err := getDynamicConfigParameters(mux.Vars(r))
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	err = dataAccessLayer.DynamicConfigurationDelete(r.Context(), layer, bundle, owner, key)
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+}
+
+// handleGetDynamicConfig handles "GET /v2/configs/{groupname}"
+func handleGetDynamicConfig(w http.ResponseWriter, r *http.Request) {
+	dataAccessLayer, err := dataaccess.Get()
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	layer, bundle, owner, key, err := getDynamicConfigParameters(mux.Vars(r))
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	exists, err := dataAccessLayer.DynamicConfigurationExists(r.Context(), layer, bundle, owner, key)
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+	if !exists {
+		http.Error(w, "No such dynamic configuration", http.StatusNotFound)
+		return
+	}
+
+	configs, err := dataAccessLayer.DynamicConfigurationGet(r.Context(), layer, bundle, owner, key)
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	json.NewEncoder(w).Encode(configs)
+}
+
+// handleGetDynamicConfigs handles "GET /v2/configs"
+func handleGetDynamicConfigs(w http.ResponseWriter, r *http.Request) {
+	dataAccessLayer, err := dataaccess.Get()
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	params := mux.Vars(r)
+	layer := data.ConfigurationLayer(params[ParameterConfigurationLayer])
+	bundle := params[ParameterConfigurationBundle]
+	owner := params[ParameterConfigurationOwner]
+	key := params[ParameterConfigurationKey]
+
+	configs, err := dataAccessLayer.DynamicConfigurationList(r.Context(), layer, bundle, owner, key)
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	json.NewEncoder(w).Encode(configs)
+}
+
+// handlePutDynamicConfiguration handles "PUT /v2/configs/{groupname}"
+func handlePutDynamicConfiguration(w http.ResponseWriter, r *http.Request) {
+	dataAccessLayer, err := dataaccess.Get()
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	var c data.DynamicConfiguration
+	err = json.NewDecoder(r.Body).Decode(&c)
+	if err != nil {
+		respondAndLogError(r.Context(), w, gerrs.ErrUnmarshal)
+		return
+	}
+
+	layer, bundle, owner, key, err := getDynamicConfigParameters(mux.Vars(r))
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+
+	c.Layer = layer
+	c.Bundle = bundle
+	c.Owner = owner
+	c.Key = key
+
+	exists, err := dataAccessLayer.DynamicConfigurationExists(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
+	if err != nil {
+		respondAndLogError(r.Context(), w, gerrs.ErrUnmarshal)
+		return
+	}
+
+	if exists {
+		err = dataAccessLayer.DynamicConfigurationDelete(r.Context(), c.Layer, c.Bundle, c.Owner, c.Key)
+		if err != nil {
+			respondAndLogError(r.Context(), w, err)
+			return
+		}
+	}
+
+	err = dataAccessLayer.DynamicConfigurationCreate(r.Context(), c)
+	if err != nil {
+		respondAndLogError(r.Context(), w, err)
+		return
+	}
+}
+
+func addConfigMethodsToRouter(router *mux.Router) {
+	router.Handle("/v2/configs/{bundle}", otelhttp.NewHandler(authCommand(handleGetDynamicConfigs, "config", "list"), "handleGetConfigs")).Methods("GET")
+	router.Handle("/v2/configs/{bundle}/{layer}", otelhttp.NewHandler(authCommand(handleGetDynamicConfigs, "config", "list"), "handleGetConfigs")).Methods("GET")
+	router.Handle("/v2/configs/{bundle}/{layer}/{owner}", otelhttp.NewHandler(authCommand(handleGetDynamicConfigs, "config", "list"), "handleGetConfigs")).Methods("GET")
+	router.Handle("/v2/configs/{bundle}/{layer}/{owner}/{key}", otelhttp.NewHandler(authCommand(handleGetDynamicConfig, "config", "info"), "handleGetConfig")).Methods("GET")
+	router.Handle("/v2/configs/{bundle}/{layer}/{owner}/{key}", otelhttp.NewHandler(authCommand(handlePutDynamicConfiguration, "config", "create"), "handlePutDynamicConfiguration")).Methods("PUT")
+	router.Handle("/v2/configs/{bundle}/{layer}/{owner}/{key}", otelhttp.NewHandler(authCommand(handleDeleteDynamicConfig, "config", "delete"), "handleDeleteConfig")).Methods("DELETE")
+}

--- a/service/config-handlers_test.go
+++ b/service/config-handlers_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 The Gort Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/getgort/gort/data"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteDynamicConfig(t *testing.T) {
+	const url = "http://example.com/v2/configs/bundle-service-delete/user/admin/foo"
+
+	dc := data.DynamicConfiguration{
+		Bundle: "bundle-service-delete",
+		Layer:  data.LayerUser,
+		Owner:  "admin",
+		Key:    "foo",
+		Value:  "test-value",
+	}
+
+	router := createTestRouter()
+
+	NewResponseTester("PUT", url).WithBody(dc).WithStatus(http.StatusOK).Test(t, router)
+
+	output := data.DynamicConfiguration{}
+	NewResponseTester("GET", url).WithOutput(&output).WithStatus(http.StatusOK).Test(t, router)
+	assert.Equal(t, dc, output)
+
+	NewResponseTester("DELETE", url).WithStatus(http.StatusOK).Test(t, router)
+
+	NewResponseTester("GET", url).WithStatus(http.StatusNotFound).Test(t, router)
+}
+
+func TestGetDynamicConfigs(t *testing.T) {
+	router := createTestRouter()
+
+	dcs := []data.DynamicConfiguration{
+		{Bundle: "bundle-service-list", Layer: data.LayerRoom, Owner: "foo", Key: "username", Value: "one"},
+		{Bundle: "bundle-service-list", Layer: data.LayerRoom, Owner: "foo", Key: "password", Value: "two"},
+		{Bundle: "bundle-service-list", Layer: data.LayerRoom, Owner: "bar", Key: "username", Value: "three"},
+		{Bundle: "bundle-service-list", Layer: data.LayerUser, Owner: "bar", Key: "username", Value: "four"},
+	}
+
+	for _, dc := range dcs {
+		url := fmt.Sprintf("http://example.com/v2/configs/%s/%s/%s/%s", dc.Bundle, dc.Layer, dc.Owner, dc.Key)
+		NewResponseTester("PUT", url).WithBody(dc).WithStatus(http.StatusOK).Test(t, router)
+	}
+
+	tests := []struct {
+		bundle   string
+		layer    data.ConfigurationLayer
+		owner    string
+		key      string
+		expected []data.DynamicConfiguration
+		status   int
+	}{
+		{
+			bundle: "",
+			status: 404,
+		},
+		{
+			bundle:   "bundle-non-existent",
+			expected: []data.DynamicConfiguration{},
+			status:   200,
+		},
+		{
+			bundle:   "bundle-service-list",
+			expected: []data.DynamicConfiguration{dcs[0], dcs[1], dcs[2], dcs[3]},
+			status:   200,
+		},
+		{
+			bundle:   "bundle-service-list",
+			layer:    data.LayerRoom,
+			expected: []data.DynamicConfiguration{dcs[0], dcs[1], dcs[2]},
+			status:   200,
+		},
+		{
+			bundle:   "bundle-service-list",
+			layer:    data.LayerUser,
+			expected: []data.DynamicConfiguration{dcs[3]},
+			status:   200,
+		},
+		{
+			bundle:   "bundle-service-list",
+			layer:    data.LayerRoom,
+			owner:    "foo",
+			expected: []data.DynamicConfiguration{dcs[0], dcs[1]},
+			status:   200,
+		},
+	}
+
+	const msg = "Index=%d Layer=%q Bundle=%q Owner=%q Key=%q"
+	for i, test := range tests {
+		url := fmt.Sprintf("http://example.com/v2/configs/%s/%s/%s/%s", test.bundle, test.layer, test.owner, test.key)
+		url = strings.TrimRight(url, "/")
+
+		list := []data.DynamicConfiguration{}
+		NewResponseTester("GET", url).WithStatus(test.status).WithOutput(&list).Test(t, router)
+		assert.ElementsMatch(t, test.expected, list, msg, i, test.layer, test.bundle, test.owner, test.key)
+	}
+}
+
+func TestPutAndGetDynamicConfiguration(t *testing.T) {
+	router := createTestRouter()
+
+	dc := data.DynamicConfiguration{
+		Bundle: "bundle",
+		Layer:  data.LayerUser,
+		Owner:  "admin",
+		Key:    "foo",
+		Value:  "test-value",
+	}
+
+	NewResponseTester("GET", "http://example.com/v2/configs/bundle/user/admin/foo").WithStatus(http.StatusNotFound).Test(t, router)
+
+	NewResponseTester("PUT", "http://example.com/v2/configs/bundle/user/admin/foo").WithBody(dc).WithStatus(http.StatusOK).Test(t, router)
+
+	output := data.DynamicConfiguration{}
+	NewResponseTester("GET", "http://example.com/v2/configs/bundle/user/admin/foo").WithOutput(&output).WithStatus(http.StatusOK).Test(t, router)
+	assert.Equal(t, dc, output)
+}

--- a/service/group-handlers.go
+++ b/service/group-handlers.go
@@ -373,7 +373,7 @@ func addGroupMethodsToRouter(router *mux.Router) {
 	router.Handle("/v2/groups/{groupname}/members/{username}", otelhttp.NewHandler(authCommand(handlePutGroupMember, "group", ""), "handlePutGroupMember")).Methods("PUT")
 
 	// Group roles
-	router.Handle("/v2/groups/{groupname}/roles", otelhttp.NewHandler(authCommand(handleGetGroupRoles, "group", "info"), "handleGetGroupMembers")).Methods("GET")
-	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handleDeleteGroupRole, "group", "add"), "handleDeleteGroupMember")).Methods("DELETE")
-	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handlePutGroupRole, "group", "add"), "handlePutGroupMember")).Methods("PUT")
+	router.Handle("/v2/groups/{groupname}/roles", otelhttp.NewHandler(authCommand(handleGetGroupRoles, "group", "info"), "handleGetGroupRoles")).Methods("GET")
+	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handleDeleteGroupRole, "group", "add"), "handleDeleteGroupRole")).Methods("DELETE")
+	router.Handle("/v2/groups/{groupname}/roles/{rolename}", otelhttp.NewHandler(authCommand(handlePutGroupRole, "group", "add"), "handlePutGroupRole")).Methods("PUT")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -136,6 +136,7 @@ func BuildRESTServer(ctx context.Context, addr string) *RESTServer {
 func addAllMethodsToRouter(router *mux.Router) {
 	addHealthzMethodToRouter(router)
 	addBundleMethodsToRouter(router)
+	addConfigMethodsToRouter(router)
 	addGroupMethodsToRouter(router)
 	addRoleMethodsToRouter(router)
 	addUserMethodsToRouter(router)
@@ -308,6 +309,7 @@ func doBootstrap(ctx context.Context, user rest.User) (rest.User, error) {
 	const adminRole = "admin"
 	var adminPermissions = []string{
 		"manage_commands",
+		"manage_configs",
 		"manage_groups",
 		"manage_roles",
 		"manage_users",
@@ -476,6 +478,8 @@ func respondAndLogError(ctx context.Context, w http.ResponseWriter, err error) {
 	case gerrs.Is(err, ErrMissingValue):
 		fallthrough
 	case gerrs.Is(err, errs.ErrFieldRequired):
+		fallthrough
+	case strings.HasPrefix(err.Error(), "dynamic configuration layers must be one of:"):
 		status = http.StatusExpectationFailed
 		log.WithError(err).WithField("status", status).Info(msg)
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -78,7 +78,7 @@ func (r ResponseTester) WithOutput(out interface{}) ResponseTester {
 // Test sends a constructed request to the provided router and performs any
 // required checks on it.
 func (r ResponseTester) Test(t *testing.T, router *mux.Router) {
-	t.Helper()
+	// t.Helper()
 
 	var bodyReader io.Reader = nil
 	if r.body != nil {
@@ -97,10 +97,12 @@ func (r ResponseTester) Test(t *testing.T, router *mux.Router) {
 
 	resp := w.Result()
 	resBody, err := io.ReadAll(resp.Body)
+
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r.out != nil {
+
+	if r.out != nil && json.Valid(resBody) {
 		err = json.Unmarshal(resBody, &r.out)
 		if err != nil {
 			t.Fatal(err)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -78,7 +78,7 @@ func (r ResponseTester) WithOutput(out interface{}) ResponseTester {
 // Test sends a constructed request to the provided router and performs any
 // required checks on it.
 func (r ResponseTester) Test(t *testing.T, router *mux.Router) {
-	// t.Helper()
+	t.Helper()
 
 	var bodyReader io.Reader = nil
 	if r.body != nil {

--- a/testing/test-default.yml
+++ b/testing/test-default.yml
@@ -3,6 +3,7 @@ gort_bundle_version: 1
 
 name: gort
 version: 0.0.1
+
 author: Matt Titmus <matthew.titmus@gmail.com>
 homepage: https://guide.getgort.io
 description: The default command bundle.
@@ -13,6 +14,7 @@ long_description: |-
 
 permissions:
   - manage_commands
+  - manage_configs
   - manage_groups
   - manage_roles
   - manage_users
@@ -42,6 +44,26 @@ commands:
     executable: [ "/bin/gort", "bundle" ]
     rules:
       - must have gort:manage_commands
+
+  config:
+    description: "Get or set dynamic configurations"
+    long_description: |-
+      Allows you to perform bundle administration.
+
+      Usage:
+        gort:config [command]
+
+      Available Commands:
+        delete      Delete an existing dynamic configuration
+        get         Get a dynamic configuration by key
+        list        List configurations for a particular bundle
+        set         Set a dynamic configuration
+
+      Flags:
+        -h, --help   help for config
+    executable: [ "/bin/gort", "config" ]
+    rules:
+      - must have gort:manage_configs
 
   group:
     description: "Manage Cog user groups"
@@ -133,7 +155,7 @@ commands:
 
       Usage:
         gort:help [flags] [command]
-    executable: [ "/bin/gort", "hidden", "commands" ]
+    executable: [ "/bin/gort", "hidden", "command" ]
     rules:
       - allow
 

--- a/testing/test-default.yml
+++ b/testing/test-default.yml
@@ -155,7 +155,7 @@ commands:
 
       Usage:
         gort:help [flags] [command]
-    executable: [ "/bin/gort", "hidden", "command" ]
+    executable: [ "/bin/gort", "hidden", "commands" ]
     rules:
       - allow
 


### PR DESCRIPTION
Added minimal support for dynamic configuration get/set via the service. The service makes calls through to the configured dynamic configuration via the `dynamic` package (currently only DAL is supported).