### PR TITLE
Don't require a public image for development

### DIFF
--- a/bundles/default.go
+++ b/bundles/default.go
@@ -19,6 +19,7 @@ package bundles
 import (
 	"bytes"
 	_ "embed"
+	"os"
 	"text/template"
 
 	"github.com/getgort/gort/data"
@@ -29,10 +30,14 @@ import (
 var s string
 
 func Default() (data.Bundle, error) {
+	bundleTag := os.Getenv("GORT_DEFAULT_BUNDLE_IMAGE_TAG")
+	if bundleTag == "" {
+		bundleTag = version.Version
+	}
 	args := struct {
 		Version string
 	}{
-		Version: version.Version,
+		Version: bundleTag,
 	}
 
 	t, err := template.New("default-bundle").Parse(s)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - ./development.yml:/config.yml
       - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - GORT_DEFAULT_BUNDLE_IMAGE_TAG=latest
     networks:
       - gort
 


### PR DESCRIPTION
When developing hidden commands, you needed to have a gort image available tagged with the current version. This could cause confusion if you ran locally with Tilt and tried to run "!help",
    
This change adds an environment variable that allows you to override the image tag used by the default bundle for running the gort binary.
    
Uses "latest" in the docker-compose file so that you're always going to get your most recent build when testing.