### PR TITLE
The `help FOO` command returns the wrong help text

### DIFF
--- a/bundles/default.yml
+++ b/bundles/default.yml
@@ -157,7 +157,7 @@ commands:
 
       Usage:
         gort:help [flags] [command]
-    executable: [ "/bin/gort", "hidden", "commands" ]
+    executable: [ "/bin/gort", "hidden", "command" ]
     rules:
       - allow
 


### PR DESCRIPTION
Fix typo in default bundle.

Fixes #204