### PR TITLE
Add the -B flag to set a base directory for client config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ development.yml
 
 # Our own binary, of course
 gort
+
+# Scratch directory for runtime files used in testing
+scratch

--- a/README.md
+++ b/README.md
@@ -246,7 +246,27 @@ A WIP design doc, including rough milestones (but not dates) [can be seen here](
 
 ## How to Run the Gort Controller
 
-For more information, take a look at the [Quick Start Guide](https://guide.getgort.io/en/latest/sections/quickstart.html) in [The Gort Guide](https://guide.getgort.io).
+To get up and running with Gort, take a look at the [Quick Start Guide](https://guide.getgort.io/en/latest/sections/quickstart.html) in [The Gort Guide](https://guide.getgort.io).
+
+Once you are familiar with how Gort fits together, you can use 
+[Tilt](https://tilt.dev/) when developing Gort to streamline the startup process.
+
+If you run:
+
+```
+tilt up
+```
+
+An instance of Gort will be started and bootstrapped ready for you to use.
+The profile used to bootstrap will be stored in a temporary directory so it doesn't
+interfere with your production profiles. As a shortcut to run a Gort client using this
+profile, you can use `./scripts/gort.sh` (you will need Go installed):
+
+```
+./scripts/gort.sh bundle list
+```
+
+This will build and run Gort and specify the scratch directory for configuration.
 
 ## The Gort Client
 

--- a/cli/bootstrap.go
+++ b/cli/bootstrap.go
@@ -82,7 +82,7 @@ func bootstrapCmd(cmd *cobra.Command, args []string) error {
 		AllowInsecure: flagBootstrapAllowInsecure,
 	}
 
-	gortClient, err := client.ConnectWithNewProfile(entry)
+	gortClient, err := client.ConnectWithNewProfile(entry, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-disable.go
+++ b/cli/bundle-disable.go
@@ -56,7 +56,7 @@ func GetBundleDisableCmd() *cobra.Command {
 func bundleDisableCmd(cmd *cobra.Command, args []string) error {
 	bundleName := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-enable.go
+++ b/cli/bundle-enable.go
@@ -64,7 +64,7 @@ func bundleEnableCmd(cmd *cobra.Command, args []string) error {
 	var bundleName = args[0]
 	var bundleVersion string
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-info.go
+++ b/cli/bundle-info.go
@@ -76,7 +76,7 @@ func bundleInfoCmd(cmd *cobra.Command, args []string) error {
 }
 
 func doBundleInfoAll(name string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}
@@ -122,7 +122,7 @@ func doBundleInfoAll(name string) error {
 }
 
 func doBundleInfoVersion(name, version string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-install.go
+++ b/cli/bundle-install.go
@@ -142,7 +142,7 @@ func GetBundleInstallCmd() *cobra.Command {
 func bundleInstallCmd(cmd *cobra.Command, args []string) error {
 	bundlefile := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-list.go
+++ b/cli/bundle-list.go
@@ -94,7 +94,7 @@ func bundleListCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--enabled and --disabled flags are mutually exclusive")
 	}
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-uninstall.go
+++ b/cli/bundle-uninstall.go
@@ -81,7 +81,7 @@ func bundleUninstallCmd(cmd *cobra.Command, args []string) error {
 		bundleVersion = args[1]
 	}
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-versions.go
+++ b/cli/bundle-versions.go
@@ -60,7 +60,7 @@ func GetBundleVersionsCmd() *cobra.Command {
 func bundleVersionsCmd(cmd *cobra.Command, args []string) error {
 	const format = "%-12s%-12s%-12s\n"
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/bundle-yaml.go
+++ b/cli/bundle-yaml.go
@@ -60,7 +60,7 @@ func bundleYamlCmd(cmd *cobra.Command, args []string) error {
 
 	// TODO Implement that no specified version returns enabled version.
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/common.go
+++ b/cli/common.go
@@ -21,8 +21,10 @@ import (
 )
 
 var (
-	// FlagGortProfile is a persistent flag
+	// FlagGortProfile is a persistent flag specifying the profile name to be used.
 	FlagGortProfile string
+	// FlagConfigBaseDir is a persistent flag specifying the base directory for storing config
+	FlagConfigBaseDir string
 )
 
 func groupNames(groups []rest.Group) []string {

--- a/cli/config-delete.go
+++ b/cli/config-delete.go
@@ -91,7 +91,7 @@ func configDeleteCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("dynamic configuration key (--key) is required")
 	}
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/config-get.go
+++ b/cli/config-get.go
@@ -87,7 +87,7 @@ func configGetCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("dynamic configuration bundle (--bundle) is required")
 	}
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/config-set.go
+++ b/cli/config-set.go
@@ -102,7 +102,7 @@ func configSetCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("dynamic configuration key (--key) is required")
 	}
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-add.go
+++ b/cli/group-add.go
@@ -65,7 +65,7 @@ func groupAddCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 	usernames := args[1:]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-create.go
+++ b/cli/group-create.go
@@ -65,7 +65,7 @@ func GetGroupCreateCmd() *cobra.Command {
 func groupCreateCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-delete.go
+++ b/cli/group-delete.go
@@ -62,7 +62,7 @@ func GetGroupDeleteCmd() *cobra.Command {
 }
 
 func groupDeleteCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-grant.go
+++ b/cli/group-grant.go
@@ -66,7 +66,7 @@ func groupGrantCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 	rolenames := args[1:]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-info.go
+++ b/cli/group-info.go
@@ -66,7 +66,7 @@ func GetGroupInfoCmd() *cobra.Command {
 func groupInfoCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-list.go
+++ b/cli/group-list.go
@@ -73,7 +73,7 @@ func GetGroupListCmd() *cobra.Command {
 }
 
 func groupListCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-remove.go
+++ b/cli/group-remove.go
@@ -66,7 +66,7 @@ func groupRemoveCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 	usernames := args[1:]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/group-revoke.go
+++ b/cli/group-revoke.go
@@ -58,7 +58,7 @@ func groupRevokeCmd(cmd *cobra.Command, args []string) error {
 	groupname := args[0]
 	rolenames := args[1:]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/hidden-command.go
+++ b/cli/hidden-command.go
@@ -59,7 +59,7 @@ func GetHiddenCommandCmd() *cobra.Command {
 }
 
 func hiddenCommandCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/permission-info.go
+++ b/cli/permission-info.go
@@ -56,7 +56,7 @@ func GetPermissionInfoCmd() *cobra.Command {
 func permissionInfoCmd(cmd *cobra.Command, args []string) error {
 	const format = "%-12s %-12s %-12s\n"
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/permission-list.go
+++ b/cli/permission-list.go
@@ -54,7 +54,7 @@ func GetPermissionListCmd() *cobra.Command {
 }
 
 func permissionListCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/profile-create.go
+++ b/cli/profile-create.go
@@ -60,7 +60,7 @@ func GetProfileCreateCmd() *cobra.Command {
 }
 
 func profileCreateCmd(cmd *cobra.Command, args []string) error {
-	profile, err := client.LoadClientProfile()
+	profile, err := client.LoadClientProfile(FlagConfigBaseDir)
 	if err != nil {
 		fmt.Println("Failed to load existing profiles:", err)
 		return nil
@@ -99,7 +99,7 @@ func profileCreateCmd(cmd *cobra.Command, args []string) error {
 		profile.Defaults.Profile = pe.Name
 	}
 
-	err = client.SaveClientProfile(profile)
+	err = client.SaveClientProfile(profile, FlagConfigBaseDir)
 	if err != nil {
 		fmt.Printf("Failed to update profile: %s\n", err.Error())
 		return nil

--- a/cli/profile-default.go
+++ b/cli/profile-default.go
@@ -59,7 +59,7 @@ func GetProfileDefaultCmd() *cobra.Command {
 }
 
 func profileDefaultCmd(cmd *cobra.Command, args []string) error {
-	profile, err := client.LoadClientProfile()
+	profile, err := client.LoadClientProfile(FlagConfigBaseDir)
 	if err != nil {
 		fmt.Println("Failed to load existing profiles:", err)
 		return nil
@@ -80,7 +80,7 @@ func profileDefaultCmd(cmd *cobra.Command, args []string) error {
 
 	profile.Defaults.Profile = name
 
-	err = client.SaveClientProfile(profile)
+	err = client.SaveClientProfile(profile, FlagConfigBaseDir)
 	if err != nil {
 		fmt.Printf("Failed to update profile: %s\n", err.Error())
 		return nil

--- a/cli/profile-delete.go
+++ b/cli/profile-delete.go
@@ -51,7 +51,7 @@ func GetProfileDeleteCmd() *cobra.Command {
 }
 
 func profileDeleteCmd(cmd *cobra.Command, args []string) error {
-	profile, err := client.LoadClientProfile()
+	profile, err := client.LoadClientProfile(FlagConfigBaseDir)
 	if err != nil {
 		fmt.Println("Failed to load existing profiles:", err)
 		return nil
@@ -77,7 +77,7 @@ func profileDeleteCmd(cmd *cobra.Command, args []string) error {
 		profile.Defaults.Profile = ""
 	}
 
-	err = client.SaveClientProfile(profile)
+	err = client.SaveClientProfile(profile, FlagConfigBaseDir)
 	if err != nil {
 		fmt.Printf("Failed to update profile: %s\n", err.Error())
 		return nil

--- a/cli/profile-list.go
+++ b/cli/profile-list.go
@@ -52,7 +52,7 @@ func GetProfileListCmd() *cobra.Command {
 }
 
 func profileListCmd(cmd *cobra.Command, args []string) error {
-	profile, err := client.LoadClientProfile()
+	profile, err := client.LoadClientProfile(FlagConfigBaseDir)
 	if err != nil {
 		fmt.Println("Failed to load existing profiles:", err)
 		return nil

--- a/cli/role-create.go
+++ b/cli/role-create.go
@@ -65,7 +65,7 @@ func GetRoleCreateCmd() *cobra.Command {
 func roleCreateCmd(cmd *cobra.Command, args []string) error {
 	rolename := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/role-delete.go
+++ b/cli/role-delete.go
@@ -55,7 +55,7 @@ func GetRoleDeleteCmd() *cobra.Command {
 }
 
 func roleDeleteCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/role-grant.go
+++ b/cli/role-grant.go
@@ -59,7 +59,7 @@ func roleGrantCmd(cmd *cobra.Command, args []string) error {
 	bundlename := args[1]
 	permissionname := args[2]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/role-info.go
+++ b/cli/role-info.go
@@ -55,7 +55,7 @@ func GetRoleInfoCmd() *cobra.Command {
 }
 
 func roleInfoCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/role-list.go
+++ b/cli/role-list.go
@@ -53,7 +53,7 @@ func GetRoleListCmd() *cobra.Command {
 }
 
 func roleListCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/role-revoke.go
+++ b/cli/role-revoke.go
@@ -59,7 +59,7 @@ func roleRevokeCmd(cmd *cobra.Command, args []string) error {
 	bundlename := args[1]
 	permissionname := args[2]
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-create.go
+++ b/cli/user-create.go
@@ -71,7 +71,7 @@ func GetUserCreateCmd() *cobra.Command {
 func userCreateCmd(cmd *cobra.Command, args []string) error {
 	username := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-delete.go
+++ b/cli/user-delete.go
@@ -54,7 +54,7 @@ func GetUserDeleteCmd() *cobra.Command {
 }
 
 func userDeleteCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-info.go
+++ b/cli/user-info.go
@@ -56,7 +56,7 @@ func GetUserInfoCmd() *cobra.Command {
 }
 
 func userInfoCmd(cmd *cobra.Command, args []string) error {
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-list.go
+++ b/cli/user-list.go
@@ -54,7 +54,7 @@ func GetUserListCmd() *cobra.Command {
 
 func userListCmd(cmd *cobra.Command, args []string) error {
 
-	gortClient, err := client.Connect(FlagGortProfile)
+	gortClient, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-map.go
+++ b/cli/user-map.go
@@ -79,7 +79,7 @@ func userMapCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("chat provider user ID is missing")
 	}
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/cli/user-update.go
+++ b/cli/user-update.go
@@ -83,7 +83,7 @@ func GetUserUpdateCmd() *cobra.Command {
 func userUpdateCmd(cmd *cobra.Command, args []string) error {
 	username := args[0]
 
-	c, err := client.Connect(FlagGortProfile)
+	c, err := client.Connect(FlagGortProfile, FlagConfigBaseDir)
 	if err != nil {
 		return err
 	}

--- a/client/client-auth.go
+++ b/client/client-auth.go
@@ -125,7 +125,7 @@ func (c *GortClient) Bootstrap(overwrite bool) (rest.User, error) {
 	endpointURL := fmt.Sprintf("%s/v2/bootstrap", c.profile.URL)
 
 	// Get profile data so we can update it afterwards
-	profile, err := LoadClientProfile()
+	profile, err := LoadClientProfile(c.configBaseDir)
 	if err != nil {
 		return rest.User{}, err
 	}
@@ -183,7 +183,7 @@ func (c *GortClient) Bootstrap(overwrite bool) (rest.User, error) {
 	}
 
 	profile.Profiles[entry.Name] = entry
-	err = SaveClientProfile(profile)
+	err = SaveClientProfile(profile, c.configBaseDir)
 	if err != nil {
 		return user, err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -54,7 +54,7 @@ func TestAllowInsecure(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
-			_, err := client.ConnectWithNewProfile(test.ProfileEntry)
+			_, err := client.ConnectWithNewProfile(test.ProfileEntry, ".")
 			if test.ExpectErr {
 				assert.Error(t, err)
 			} else {

--- a/client/profile.go
+++ b/client/profile.go
@@ -70,10 +70,10 @@ func (pe ProfileEntry) User() rest.User {
 // loadClientProfile loads and returns the complete client profile. If there's
 // no profile file, an empty Profile is returned. An error is returned if
 // there's an underlying IO error.
-func LoadClientProfile() (Profile, error) {
+func LoadClientProfile(baseDir string) (Profile, error) {
 	profile := Profile{Profiles: make(map[string]ProfileEntry)}
 
-	configDir, err := getGortConfigDir()
+	configDir, err := getGortConfigDir(baseDir)
 	if err != nil {
 		return Profile{}, err
 	}
@@ -122,8 +122,8 @@ func LoadClientProfile() (Profile, error) {
 	return profile, err
 }
 
-func SaveClientProfile(profile Profile) error {
-	configDir, err := getGortConfigDir()
+func SaveClientProfile(profile Profile, baseDir string) error {
+	configDir, err := getGortConfigDir(baseDir)
 	if err != nil {
 		return err
 	}

--- a/cmd-root.go
+++ b/cmd-root.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 
 	"github.com/getgort/gort/cli"
@@ -35,6 +36,17 @@ func GetRootCmd() *cobra.Command {
 		Short:        rootShort,
 		Long:         rootLong,
 		SilenceUsage: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Load the home dir into FlagConfigBaseDir if not specified.
+			if cli.FlagConfigBaseDir == "" {
+				var err error
+				cli.FlagConfigBaseDir, err = homedir.Dir()
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		},
 	}
 
 	root.AddCommand(GetStartCmd())
@@ -50,6 +62,7 @@ func GetRootCmd() *cobra.Command {
 	root.AddCommand(cli.GetVersionCmd())
 
 	root.PersistentFlags().StringVarP(&cli.FlagGortProfile, "profile", "P", "", "The Gort profile within the config file to use")
+	root.PersistentFlags().StringVarP(&cli.FlagConfigBaseDir, "baseDir", "B", "", "Base directory for configuration, defaults to $HOME. A .gort directory will be added here.")
 
 	return root
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,4 @@ services:
 
 networks:
   gort:
+    name: gort

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+wait-for-url() {
+    echo "Testing $1"
+    timeout -s TERM 45 bash -c \
+    'while [[ "$(curl --insecure -s -o /dev/null -L -w ''%{http_code}'' ${0})" != "200" ]];\
+    do echo "Waiting for ${0}" && sleep 2;\
+    done' ${1}
+    echo "OK!"
+    curl -I $1
+}
+
+wait-for-url https://localhost:4000/v2/healthz
+
+go run . bootstrap -F -B ./scratch https://localhost:4000 --allow-insecure

--- a/scripts/gort.sh
+++ b/scripts/gort.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+go run . -B ./scratch $@


### PR DESCRIPTION
So you can run test instances of Gort without accidentally overwriting any
production profiles you may be using, this change allows the location of the
.gort directory to be overriden with a command line flag.

This change also updates the Tiltfile to take advantage of the change, and
automatically bootstrap the test instance of Gort to save time during development.

The Tilt image for Tilt is also tagged with the version number so pre-release versions
can be tested with the built-in commands.

Fix #215 
Also replaces PR #211 