### PR TITLE
Slack link bookmarks

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -339,12 +339,15 @@ func handleAdvancedOutput(ctx context.Context, adapter Adapter, output []io.Adva
 		if err != nil {
 			msgRef = nil
 			if o.Adapter != "" {
-
+				a1, err := GetAdapter(o.Adapter)
+				if err != nil {
+					a = a1
+				}
 			}
 		} else {
 			a, err = GetAdapter(msgRef.Adapter)
 			if err != nil {
-				e.WithError(err).Error("Couldn't find specified adapter")
+				e.WithError(err).Error("Couldn't find specified adapter from MessageRef")
 				return nil
 			}
 		}

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -86,6 +86,8 @@ var (
 
 // Adapter represents a connection to a chat provider.
 type Adapter interface {
+	// BookmarkLink bookmarks a link in the specified chanel, if the adapter
+	// supports this.
 	BookmarkLink(ctx context.Context, channelID, title, link string) error
 
 	// GetChannelInfo provides info on a specific provider channel accessible

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -257,6 +257,11 @@ var _ Adapter = &testAdapter{}
 
 type testAdapter struct{}
 
+func (t *testAdapter) BookmarkLink(ctx context.Context, channelID, title, link string) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (t *testAdapter) React(ctx context.Context, message MessageRef, emoji emoji.Emoji) error {
 	//TODO implement me
 	panic("implement me")

--- a/adapter/discord/adapter.go
+++ b/adapter/discord/adapter.go
@@ -60,6 +60,10 @@ type Adapter struct {
 	events   chan *adapter.ProviderEvent
 }
 
+func (s *Adapter) BookmarkLink(ctx context.Context, channelID, title, link string) error {
+	return fmt.Errorf("discord does not curently support bookmarking links")
+}
+
 func (s *Adapter) React(ctx context.Context, message adapter.MessageRef, emoji emoji.Emoji) error {
 	return s.session.MessageReactionAdd(message.ChannelID, message.ID, string(emoji.Unicode()))
 }

--- a/adapter/slack/classic_adapter.go
+++ b/adapter/slack/classic_adapter.go
@@ -44,6 +44,16 @@ type ClassicAdapter struct {
 	rtm      *slack.RTM
 }
 
+func (s *ClassicAdapter) BookmarkLink(ctx context.Context, channelID, title, link string) error {
+	_, err := s.client.AddBookmarkContext(ctx, channelID, slack.AddBookmarkParameters{
+		Title: title,
+		Type:  "link",
+		Link:  link,
+	})
+	//TODO this could support emoji
+	return err
+}
+
 func (s *ClassicAdapter) React(ctx context.Context, message adapter.MessageRef, emoji emoji.Emoji) error {
 	return s.client.AddReactionContext(ctx, emoji.Shortname(), slack.ItemRef{
 		Channel:   message.ChannelID,

--- a/adapter/slack/socketmode_adapter.go
+++ b/adapter/slack/socketmode_adapter.go
@@ -45,6 +45,16 @@ type SocketModeAdapter struct {
 	provider     data.SlackProvider
 }
 
+func (s *SocketModeAdapter) BookmarkLink(ctx context.Context, channelID, title, link string) error {
+	_, err := s.client.AddBookmarkContext(ctx, channelID, slack.AddBookmarkParameters{
+		Title: title,
+		Type:  "link",
+		Link:  link,
+	})
+	//TODO this could support emoji
+	return err
+}
+
 func (s *SocketModeAdapter) React(ctx context.Context, message adapter.MessageRef, emoji emoji.Emoji) error {
 	return s.client.AddReactionContext(ctx, emoji.Shortname(), slack.ItemRef{
 		Channel:   message.ChannelID,

--- a/data/io/advancedio.go
+++ b/data/io/advancedio.go
@@ -27,6 +27,11 @@ import (
 const (
 	ActionReply = "reply"
 	ActionReact = "react"
+
+	// ActionBookmark is used to bookmark a link in a given chanel. This is
+	// currently only supported on slack. It requires a link in Content, a
+	// Title, a ChannelID, and optionally an Adapter.
+	ActionBookmark = "bookmark"
 )
 
 // CommandInfo represents a command typed in by a user. Unlike
@@ -123,4 +128,14 @@ type AdvancedOutput struct {
 	// Content is the content associated with an action, for example text for a
 	// reply or the emoji for a reaction.
 	Content string
+
+	// Title is the title of something to be created, for example a slack
+	// bookmark.
+	Title string
+
+	// Adapter is the name of a specific adapter in which to perform the action.
+	// This is usually optional, and will default to the adapter from which the
+	// command that generated this output was triggered. Actions that take
+	// MessageRef may use the adapter of that message.
+	Adapter string
 }


### PR DESCRIPTION
This PR adds an advanced output action, `bookmark`, which creates a link bookmark in slack and is a no-op in discord. The action requires a `Title`, link in `Content`, and an optional `Adapter`. If no adapter is specified, the one from which the command was issued will be used.