### PR TITLE
Fix dynamic config list in memory

### DIFF
--- a/dataaccess/memory/dynamic-config-access.go
+++ b/dataaccess/memory/dynamic-config-access.go
@@ -98,7 +98,7 @@ func (da *InMemoryDataAccess) DynamicConfigurationGet(_ context.Context, layer d
 // DynamicConfigurationList will list matching configurations. Empty values
 // are treated as wildcards. Bundle (at a minimum) must be not empty.
 func (da *InMemoryDataAccess) DynamicConfigurationList(_ context.Context, layer data.ConfigurationLayer, bundle, owner, key string) ([]data.DynamicConfiguration, error) {
-	const wildcard = `([^\|]+)`
+	const wildcard = `([^\|]*)`
 
 	if bundle == "" {
 		return nil, errs.ErrEmptyConfigBundle


### PR DESCRIPTION
The in-memory implementation of dynamic config had a slightly incorrect regex for its wildcard, resulting in `DynamicConfigurationList` always returning an empty slice. This is now corrected.